### PR TITLE
Fix blockquote rendering in PDF export for Info/Tip/Warning/Note components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
@@ -135,7 +136,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
@@ -144,6 +146,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -154,7 +157,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
@@ -163,6 +167,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -173,7 +178,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1119,7 +1125,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1638,8 +1643,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1736,7 +1740,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3332,7 +3335,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3464,7 +3466,6 @@
       "integrity": "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
@@ -3503,7 +3504,6 @@
       "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
       "integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.0",
         "debug": "^4.1.1",
@@ -4141,7 +4141,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4220,7 +4219,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -193,21 +193,29 @@ export class PandocPdfService {
     // </Accordion> -> remove
     cleaned = cleaned.replace(/<\/Accordion>/g, '\n');
 
-    // <Info> / </Info> -> blockquote marker (ℹ️)
-    cleaned = cleaned.replace(/<Info>/g, '\n> **Note:** ');
-    cleaned = cleaned.replace(/<\/Info>/g, '\n');
-
-    // <Tip> / </Tip> -> blockquote marker (💡)
-    cleaned = cleaned.replace(/<Tip>/g, '\n> **Tip:** ');
-    cleaned = cleaned.replace(/<\/Tip>/g, '\n');
-
-    // <Warning> / </Warning> -> blockquote marker (⚠️)
-    cleaned = cleaned.replace(/<Warning>/g, '\n> **Warning:** ');
-    cleaned = cleaned.replace(/<\/Warning>/g, '\n');
-
-    // <Note> / </Note> -> blockquote marker
-    cleaned = cleaned.replace(/<Note>/g, '\n> **Note:** ');
-    cleaned = cleaned.replace(/<\/Note>/g, '\n');
+    // <Info|Tip|Warning|Note> -> blockquote with marker
+    // Convert the entire block content so every inner line gets the `> ` prefix.
+    // This prevents orphaned list items outside the blockquote that break LaTeX.
+    cleaned = cleaned.replace(
+      /<(Info|Tip|Warning|Note)>([\s\S]*?)<\/\1>/g,
+      (_match, tag, innerContent) => {
+        const label = tag === 'Tip' ? 'Tip' : tag === 'Warning' ? 'Warning' : 'Note';
+        const lines = innerContent.split('\n');
+        const quotedLines = [];
+        let firstContent = true;
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue; // skip blank lines inside the component
+          if (firstContent) {
+            quotedLines.push(`> **${label}:** ${trimmed}`);
+            firstContent = false;
+          } else {
+            quotedLines.push(`> ${trimmed}`);
+          }
+        }
+        return '\n' + quotedLines.join('\n') + '\n';
+      }
+    );
 
     // Remove any remaining JSX/MDX component tags (PascalCase = JSX convention)
     // Strips only the tags, inner content is preserved
@@ -268,7 +276,16 @@ export class PandocPdfService {
       });
     });
 
-    // 4. 将图片 URL 中的 fm=webp 替换为 fm=png（LaTeX 不支持 webp 格式）
+    // 4. 修复 blockquote 中的列表项（防止 LaTeX \end{quote} / missing \item 错误）
+    // 4a. Remove empty list items inside blockquotes: "> -" or "> *" with no content
+    cleaned = cleaned.replace(/^(>\s*)-\s*$/gm, '$1');
+    cleaned = cleaned.replace(/^(>\s*)\*\s*$/gm, '$1');
+
+    // 4b. Ensure a blank line between blockquote prose and blockquote list items
+    // e.g. "> text\n> - item" -> "> text\n>\n> - item"
+    cleaned = cleaned.replace(/^(>.*[^\s-*].*)\n(>\s*[-*]\s+\S)/gm, '$1\n>\n$2');
+
+    // 5. 将图片 URL 中的 fm=webp 替换为 fm=png（LaTeX 不支持 webp 格式）
     cleaned = cleaned.replace(/fm=webp/g, 'fm=png');
 
     return cleaned;

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -244,6 +244,41 @@ describe('PandocPdfService', () => {
       expect(result).toBe(expected);
     });
 
+    it('should convert Info component with list items to fully-quoted blockquote', () => {
+      const input = '<Info>\n- Step 1\n- Step 2\n</Info>';
+      const result = service._cleanMarkdownContent(input);
+      expect(result).toContain('> **Note:** - Step 1');
+      expect(result).toContain('> - Step 2');
+      // No unquoted list items
+      expect(result).not.toMatch(/^- Step/m);
+    });
+
+    it('should convert Tip component with multiline content to blockquote', () => {
+      const input = '<Tip>\nDo this first.\n- Option A\n- Option B\n</Tip>';
+      const result = service._cleanMarkdownContent(input);
+      expect(result).toContain('> **Tip:** Do this first.');
+      expect(result).toContain('> - Option A');
+      expect(result).toContain('> - Option B');
+    });
+
+    it('should convert Warning component to blockquote', () => {
+      const input = '<Warning>\nDanger ahead!\n</Warning>';
+      const result = service._cleanMarkdownContent(input);
+      expect(result).toContain('> **Warning:** Danger ahead!');
+    });
+
+    it('should remove empty list items inside blockquotes', () => {
+      const input = '> -\n> text after';
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toMatch(/^>\s*-\s*$/m);
+    });
+
+    it('should insert blank line between blockquote prose and list', () => {
+      const input = '> Some text\n> - item 1';
+      const result = service._cleanMarkdownContent(input);
+      expect(result).toBe('> Some text\n>\n> - item 1');
+    });
+
     it('should handle mixed backtick lengths correctly', () => {
       const input =
         '````markdown theme={null}\n' + '```bash\n' + 'echo "hello"\n' + '```\n' + '````';


### PR DESCRIPTION
## Summary
Refactored the handling of Info, Tip, Warning, and Note components to properly convert them into fully-quoted blockquotes in Markdown, preventing LaTeX compilation errors caused by orphaned list items outside blockquotes.

## Key Changes
- **Unified component conversion**: Replaced four separate regex replacements with a single regex that captures all Info/Tip/Warning/Note components and processes their inner content line-by-line
- **Full blockquote prefixing**: Every line within these components now receives the `> ` blockquote prefix, ensuring list items and other content remain properly nested within the blockquote
- **Blockquote list formatting fixes**: Added two new regex patterns to:
  - Remove empty list items inside blockquotes (e.g., `> -` with no content)
  - Insert blank lines between blockquote prose and blockquote list items to prevent LaTeX `\end{quote}` / missing `\item` errors
- **Comprehensive test coverage**: Added 5 new test cases covering Info/Tip/Warning components with list items, multiline content, empty list items, and prose-to-list transitions

## Implementation Details
The new implementation uses a callback function in the regex replacement to:
1. Extract the tag type and inner content
2. Split content by newlines and filter out blank lines
3. Apply the appropriate label (Tip, Warning, or Note) to the first non-empty line
4. Prefix all subsequent lines with `> ` to maintain blockquote structure
5. Return properly formatted blockquote with surrounding newlines

This prevents LaTeX compilation failures that occurred when list items appeared outside blockquotes due to incomplete prefixing of component content.

https://claude.ai/code/session_01Cxq9aMzxUnkPJxKSnehcgy