### PR TITLE
fix: strip MDX module-level export/import declarations before Pandoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "async": "^3.2.5",
         "chalk": "^5.6.2",
         "joi": "^18.1.2",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0",
         "p-limit": "^7.3.0",
         "p-queue": "^9.1.1",
         "pdf-lib": "^1.17.1",
@@ -19,6 +22,7 @@
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "turndown": "^7.2.4",
+        "unist-util-visit": "^5.1.0",
         "winston": "^3.19.0"
       },
       "devDependencies": {
@@ -923,8 +927,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -932,6 +953,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -953,6 +983,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -1123,7 +1159,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1136,7 +1171,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -1381,6 +1415,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1401,6 +1445,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chromium-bidi": {
@@ -1599,6 +1683,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1629,6 +1726,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1637,6 +1743,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/devtools-protocol": {
@@ -1939,6 +2058,30 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/estree-walker": {
@@ -2369,6 +2512,30 @@
         "node": ">= 12"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2380,6 +2547,16 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
@@ -2420,6 +2597,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-plain-object": {
@@ -2933,6 +3120,16 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2971,6 +3168,155 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge-deep": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
@@ -2984,6 +3330,602 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3250,6 +4192,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -3947,6 +4914,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4110,6 +5091,74 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4134,6 +5183,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.3",
@@ -4489,6 +5552,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "async": "^3.2.5",
     "chalk": "^5.6.2",
     "joi": "^18.1.2",
+    "mdast-util-from-markdown": "^2.0.3",
+    "mdast-util-mdx": "^3.0.0",
+    "micromark-extension-mdxjs": "^3.0.0",
     "p-limit": "^7.3.0",
     "p-queue": "^9.1.1",
     "pdf-lib": "^1.17.1",
@@ -45,6 +48,7 @@
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "turndown": "^7.2.4",
+    "unist-util-visit": "^5.1.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -178,9 +178,14 @@ export class PandocPdfService {
       let segment = parts[i];
 
       // 1) Multi-line: `export const|default|function|let|var X = ...` closed
-      //    by a column-0 `};` (or `});`, `})`) line.
+      //    by a column-0 `};` or `});` line. The closing semicolon is
+      //    required — this is what distinguishes the real JS closer from
+      //    bare `}` characters that appear inside embedded CSS template
+      //    literals (e.g. `const STYLES = \`.foo { color: red; }\``), which
+      //    would otherwise cause the non-greedy match to stop early and
+      //    leave the CSS content behind in the markdown.
       segment = segment.replace(
-        /^export[ \t]+(?:const|default|function|let|var)\b[\s\S]*?^\}[)]?;?[ \t]*$/gm,
+        /^export[ \t]+(?:const|default|function|let|var)\b[\s\S]*?^\}\)?;[ \t]*$/gm,
         ''
       );
 

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -173,41 +173,71 @@ export class PandocPdfService {
   _stripMdxModuleDeclarations(content) {
     if (!content) return content;
 
-    // Split by fenced code blocks (``` or ~~~). Capture groups keep the
-    // fences in the split result so we can reassemble them untouched.
-    const parts = content.split(/(^(?:`{3,}|~{3,})[^\n]*\n[\s\S]*?^(?:`{3,}|~{3,})[ \t]*$)/gm);
+    // Walk line-by-line, tracking fenced code blocks properly:
+    // a closing fence must use the same character (` or ~) as the opener
+    // and have at least as many repetitions (CommonMark spec).
+    const lines = content.split('\n');
+    const proseRanges = []; // [startIdx, endIdx) of prose line ranges
+    let inFence = false;
+    let fenceChar = '';
+    let fenceCount = 0;
+    let proseStart = 0;
 
-    for (let i = 0; i < parts.length; i += 2) {
-      let segment = parts[i];
+    for (let i = 0; i < lines.length; i++) {
+      const fenceMatch = lines[i].match(/^(`{3,}|~{3,})/);
 
-      // 1) Multi-line: `export const|default|function|let|var X = ...` closed
-      //    by a column-0 `};` or `});` line. The closing semicolon is
-      //    required — this is what distinguishes the real JS closer from
-      //    bare `}` characters that appear inside embedded CSS template
-      //    literals (e.g. `const STYLES = \`.foo { color: red; }\``), which
-      //    would otherwise cause the non-greedy match to stop early and
-      //    leave the CSS content behind in the markdown.
+      if (!inFence && fenceMatch) {
+        // Opening fence — save preceding prose range
+        if (i > proseStart) proseRanges.push([proseStart, i]);
+        inFence = true;
+        fenceChar = fenceMatch[1][0];
+        fenceCount = fenceMatch[1].length;
+      } else if (
+        inFence &&
+        fenceMatch &&
+        fenceMatch[1][0] === fenceChar &&
+        fenceMatch[1].length >= fenceCount &&
+        lines[i].slice(fenceMatch[1].length).trim() === ''
+      ) {
+        // Valid closing fence
+        inFence = false;
+        proseStart = i + 1;
+      }
+    }
+    // Remaining lines after last fence are prose
+    if (!inFence && proseStart < lines.length) {
+      proseRanges.push([proseStart, lines.length]);
+    }
+
+    // Strip MDX declarations only in prose segments
+    for (const [start, end] of proseRanges) {
+      let segment = lines.slice(start, end).join('\n');
+
+      // 1) Multi-line export closed by column-0 `};` or `});`
       segment = segment.replace(
         /^export[ \t]+(?:const|default|function|let|var)\b[\s\S]*?^\}\)?;[ \t]*$/gm,
         ''
       );
 
-      // 2) Single-line: `export const foo = 'bar';`
+      // 2) Single-line export
       segment = segment.replace(
         /^export[ \t]+(?:const|default|function|let|var)\b[^\n]*;[ \t]*$/gm,
         ''
       );
 
-      // 3) Top-level MDX imports: `import X from '...';`
+      // 3) Top-level MDX imports
       segment = segment.replace(
         /^import[ \t]+[^\n;]*?\bfrom[ \t]+['"][^'"\n]+['"];?[ \t]*$/gm,
         ''
       );
 
-      parts[i] = segment;
+      const newLines = segment.split('\n');
+      for (let i = start; i < end; i++) {
+        lines[i] = newLines[i - start];
+      }
     }
 
-    return parts.join('');
+    return lines.join('\n');
   }
 
   /**

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -151,6 +151,58 @@ export class PandocPdfService {
   }
 
   /**
+   * Strip MDX module-level `export`/`import` declarations that leak into
+   * markdown when .mdx pages are scraped without JSX compilation.
+   *
+   * These appear at column 0 in the source (by MDX convention) and their
+   * multi-line bodies close with a column-0 `};` line. Because the JS code
+   * contains template literals with backticks, when Pandoc treats it as prose
+   * it emits `\(` (inline math open) inside escaped regexes, causing
+   * "Extra }, or forgotten $." LaTeX errors.
+   *
+   * Preserves fenced code blocks so in-doc JS/Python examples that happen to
+   * start with `export` or `import` are not affected.
+   *
+   * @param {string} content
+   * @returns {string}
+   * @private
+   */
+  _stripMdxModuleDeclarations(content) {
+    if (!content) return content;
+
+    // Split by fenced code blocks (``` or ~~~). Capture groups keep the
+    // fences in the split result so we can reassemble them untouched.
+    const parts = content.split(/(^(?:`{3,}|~{3,})[^\n]*\n[\s\S]*?^(?:`{3,}|~{3,})[ \t]*$)/gm);
+
+    for (let i = 0; i < parts.length; i += 2) {
+      let segment = parts[i];
+
+      // 1) Multi-line: `export const|default|function|let|var X = ...` closed
+      //    by a column-0 `};` (or `});`, `})`) line.
+      segment = segment.replace(
+        /^export[ \t]+(?:const|default|function|let|var)\b[\s\S]*?^\}[)]?;?[ \t]*$/gm,
+        ''
+      );
+
+      // 2) Single-line: `export const foo = 'bar';`
+      segment = segment.replace(
+        /^export[ \t]+(?:const|default|function|let|var)\b[^\n]*;[ \t]*$/gm,
+        ''
+      );
+
+      // 3) Top-level MDX imports: `import X from '...';`
+      segment = segment.replace(
+        /^import[ \t]+[^\n;]*?\bfrom[ \t]+['"][^'"\n]+['"];?[ \t]*$/gm,
+        ''
+      );
+
+      parts[i] = segment;
+    }
+
+    return parts.join('');
+  }
+
+  /**
    * 清理 Markdown 内容，修复 Pandoc 不支持的语法
    * @param {string} content
    * @returns {string}
@@ -159,10 +211,17 @@ export class PandocPdfService {
   _cleanMarkdownContent(content) {
     if (!content) return content;
 
+    // 00. Strip MDX module-level `export`/`import` declarations that leak into
+    // markdown when .mdx pages are scraped without running through a JSX
+    // compiler. Pandoc otherwise treats these as prose and emits invalid LaTeX
+    // (e.g. JS template literal backticks opening math mode). Must run before
+    // any other transformation so that top-level `};` is still at column 0.
+    let cleaned = this._stripMdxModuleDeclarations(content);
+
     // 1. 修复代码块中的 theme={...} 属性
     // ```markdown theme={null} -> ```markdown
     // 支持任意数量的反引号 (>=3)
-    let cleaned = content.replace(/^(`{3,})(\w+)\s+theme=\{[^}]+\}/gm, '$1$2');
+    cleaned = cleaned.replace(/^(`{3,})(\w+)\s+theme=\{[^}]+\}/gm, '$1$2');
 
     // 0. 处理 MDX/JSX 自定义组件
 

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -2,6 +2,9 @@
 import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { mdxFromMarkdown } from 'mdast-util-mdx';
+import { mdxjs } from 'micromark-extension-mdxjs';
 
 /**
  * PandocPdfService
@@ -313,6 +316,195 @@ export class PandocPdfService {
   }
 
   /**
+   * Strip all MDX constructs from content using AST-based parsing for maximum
+   * reliability. Handles:
+   * - `mdxjsEsm`: module-level `export`/`import` declarations
+   * - `mdxJsxFlowElement`/`mdxJsxTextElement`: JSX components
+   *   - Known components are transformed (Info→blockquote, Step→header, etc.)
+   *   - Unknown PascalCase components have tags stripped, children preserved
+   *   - HTML elements (lowercase) are preserved
+   * - `mdxFlowExpression`/`mdxTextExpression`: `{expression}` blocks
+   *
+   * Falls back to regex-based stripping if AST parsing fails.
+   *
+   * @param {string} content
+   * @returns {string}
+   * @private
+   */
+  _stripMdxWithAst(content) {
+    if (!content) return content;
+
+    try {
+      const tree = fromMarkdown(content, {
+        extensions: [mdxjs()],
+        mdastExtensions: [mdxFromMarkdown()],
+      });
+
+      const edits = [];
+
+      const getAttr = (node, attrName) => {
+        const attr = node.attributes?.find((a) => a.name === attrName);
+        if (!attr) return '';
+        return typeof attr.value === 'string' ? attr.value : '';
+      };
+
+      const collectEdits = (node) => {
+        if (node.type === 'mdxjsEsm') {
+          edits.push([node.position.start.offset, node.position.end.offset, '']);
+          return;
+        }
+
+        if (node.type === 'mdxFlowExpression' || node.type === 'mdxTextExpression') {
+          edits.push([node.position.start.offset, node.position.end.offset, '']);
+          return;
+        }
+
+        if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+          const name = node.name;
+          const start = node.position.start.offset;
+          const end = node.position.end.offset;
+
+          // Lowercase/null → HTML element, recurse into children only
+          if (!name || name[0] < 'A' || name[0] > 'Z') {
+            if (node.children) node.children.forEach(collectEdits);
+            return;
+          }
+
+          // Extract and recursively process inner content
+          let innerContent = '';
+          if (node.children?.length > 0) {
+            const innerStart = node.children[0].position.start.offset;
+            const innerEnd = node.children[node.children.length - 1].position.end.offset;
+            innerContent = content.slice(innerStart, innerEnd);
+            innerContent = this._stripMdxWithAst(innerContent);
+          }
+
+          let replacement;
+          switch (name) {
+            case 'Steps':
+            case 'Tabs':
+            case 'AccordionGroup':
+              replacement = innerContent;
+              break;
+            case 'Step': {
+              const title = getAttr(node, 'title');
+              replacement = title ? `\n### ${title}\n\n${innerContent}\n` : `\n${innerContent}\n`;
+              break;
+            }
+            case 'Tab': {
+              const title = getAttr(node, 'title');
+              replacement = title ? `\n#### ${title}\n\n${innerContent}\n` : `\n${innerContent}\n`;
+              break;
+            }
+            case 'Accordion': {
+              const title = getAttr(node, 'title');
+              replacement = title ? `\n#### ${title}\n\n${innerContent}\n` : `\n${innerContent}\n`;
+              break;
+            }
+            case 'Info':
+            case 'Tip':
+            case 'Warning':
+            case 'Note': {
+              const label = name === 'Tip' ? 'Tip' : name === 'Warning' ? 'Warning' : 'Note';
+              replacement = this._contentToBlockquote(innerContent, label);
+              break;
+            }
+            default:
+              replacement = innerContent;
+              break;
+          }
+
+          edits.push([start, end, replacement]);
+          return;
+        }
+
+        // For all other node types, recurse into children
+        if (node.children) node.children.forEach(collectEdits);
+      };
+
+      collectEdits(tree);
+
+      // Sort by start offset descending, apply from end to start
+      edits.sort((a, b) => b[0] - a[0]);
+
+      let result = content;
+      for (const [s, e, replacement] of edits) {
+        result = result.slice(0, s) + replacement + result.slice(e);
+      }
+
+      return result;
+    } catch (error) {
+      this.logger?.warn?.('MDX AST parse failed, falling back to regex', {
+        error: error.message,
+      });
+      return this._stripMdxWithRegex(content);
+    }
+  }
+
+  /**
+   * Regex/scanner fallback for MDX stripping when AST parsing fails.
+   * Combines module declaration stripping, named component transforms,
+   * and PascalCase JSX tag stripping.
+   *
+   * @param {string} content
+   * @returns {string}
+   * @private
+   */
+  _stripMdxWithRegex(content) {
+    if (!content) return content;
+
+    let result = this._stripMdxModuleDeclarations(content);
+
+    result = result.replace(/<\/?Steps>/g, '');
+    result = result.replace(/<Step[^>]*title="([^"]+)"[^>]*>/g, '\n### $1\n');
+    result = result.replace(/<\/Step>/g, '\n');
+    result = result.replace(/<\/?Tabs>/g, '');
+    result = result.replace(/<Tab[^>]*title="([^"]+)"[^>]*>/g, '\n#### $1\n');
+    result = result.replace(/<\/Tab>/g, '\n');
+    result = result.replace(/<\/?AccordionGroup>/g, '');
+    result = result.replace(/<Accordion[^>]*title="([^"]+)"[^>]*>/g, '\n#### $1\n');
+    result = result.replace(/<\/Accordion>/g, '\n');
+    result = result.replace(
+      /<(Info|Tip|Warning|Note)>([\s\S]*?)<\/\1>/g,
+      (_match, tag, innerContent) => {
+        const label = tag === 'Tip' ? 'Tip' : tag === 'Warning' ? 'Warning' : 'Note';
+        return this._contentToBlockquote(innerContent, label);
+      }
+    );
+
+    result = this._stripPascalCaseJsxTags(result);
+
+    return result;
+  }
+
+  /**
+   * Convert text content to a markdown blockquote with a label.
+   *
+   * @param {string} innerContent
+   * @param {string} label
+   * @returns {string}
+   * @private
+   */
+  _contentToBlockquote(innerContent, label) {
+    if (!innerContent?.trim()) return '';
+
+    const lines = innerContent.split('\n');
+    const quotedLines = [];
+    let firstContent = true;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (firstContent) {
+        quotedLines.push(`> **${label}:** ${trimmed}`);
+        firstContent = false;
+      } else {
+        quotedLines.push(`> ${trimmed}`);
+      }
+    }
+    return '\n' + quotedLines.join('\n') + '\n';
+  }
+
+  /**
    * 清理 Markdown 内容，修复 Pandoc 不支持的语法
    * @param {string} content
    * @returns {string}
@@ -321,81 +513,14 @@ export class PandocPdfService {
   _cleanMarkdownContent(content) {
     if (!content) return content;
 
-    // 00. Strip MDX module-level `export`/`import` declarations that leak into
-    // markdown when .mdx pages are scraped without running through a JSX
-    // compiler. Pandoc otherwise treats these as prose and emits invalid LaTeX
-    // (e.g. JS template literal backticks opening math mode). Must run before
-    // any other transformation so that top-level `};` is still at column 0.
-    let cleaned = this._stripMdxModuleDeclarations(content);
+    // 00. Strip all MDX constructs (module-level JS, JSX components, expressions)
+    // using AST-based approach with regex fallback.
+    let cleaned = this._stripMdxWithAst(content);
 
     // 1. 修复代码块中的 theme={...} 属性
     // ```markdown theme={null} -> ```markdown
     // 支持任意数量的反引号 (>=3)
     cleaned = cleaned.replace(/^(`{3,})(\w+)\s+theme=\{[^}]+\}/gm, '$1$2');
-
-    // 0. 处理 MDX/JSX 自定义组件
-
-    // <Steps> / </Steps> -> remove
-    cleaned = cleaned.replace(/<\/?Steps>/g, '');
-
-    // <Step title="..."> -> ### ...
-    cleaned = cleaned.replace(/<Step[^>]*title="([^"]+)"[^>]*>/g, '\n### $1\n');
-
-    // </Step> -> remove
-    cleaned = cleaned.replace(/<\/Step>/g, '\n');
-
-    // <Tabs> / </Tabs> -> remove (keep content of all tabs)
-    cleaned = cleaned.replace(/<\/?Tabs>/g, '');
-
-    // <Tab title="..."> -> #### ... (use H4 for tab titles)
-    cleaned = cleaned.replace(/<Tab[^>]*title="([^"]+)"[^>]*>/g, '\n#### $1\n');
-
-    // </Tab> -> remove
-    cleaned = cleaned.replace(/<\/Tab>/g, '\n');
-
-    // <AccordionGroup> / </AccordionGroup> -> remove
-    cleaned = cleaned.replace(/<\/?AccordionGroup>/g, '');
-
-    // <Accordion title="..." ...> -> #### ...
-    cleaned = cleaned.replace(/<Accordion[^>]*title="([^"]+)"[^>]*>/g, '\n#### $1\n');
-
-    // </Accordion> -> remove
-    cleaned = cleaned.replace(/<\/Accordion>/g, '\n');
-
-    // <Info|Tip|Warning|Note> -> blockquote with marker
-    // Convert the entire block content so every inner line gets the `> ` prefix.
-    // This prevents orphaned list items outside the blockquote that break LaTeX.
-    cleaned = cleaned.replace(
-      /<(Info|Tip|Warning|Note)>([\s\S]*?)<\/\1>/g,
-      (_match, tag, innerContent) => {
-        const label = tag === 'Tip' ? 'Tip' : tag === 'Warning' ? 'Warning' : 'Note';
-        const lines = innerContent.split('\n');
-        const quotedLines = [];
-        let firstContent = true;
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed) continue; // skip blank lines inside the component
-          if (firstContent) {
-            quotedLines.push(`> **${label}:** ${trimmed}`);
-            firstContent = false;
-          } else {
-            quotedLines.push(`> ${trimmed}`);
-          }
-        }
-        return '\n' + quotedLines.join('\n') + '\n';
-      }
-    );
-
-    // Remove any remaining JSX/MDX component tags (PascalCase = JSX convention).
-    // Strips only the tags, inner content is preserved.
-    // e.g. <Frame><img .../></Frame> -> <img .../>
-    //
-    // Uses a brace-aware scanner rather than a plain regex because JSX
-    // attributes can embed nested JSX, e.g.
-    //   <Experiment treatment={<InstallConfigurator />} />
-    // A naive `<[A-Z]...[^>]*>` would stop at the inner `/>` and leave
-    // `} />` behind as garbage prose.
-    cleaned = this._stripPascalCaseJsxTags(cleaned);
 
     // 0.1 修复缩进
     // 移除 2-4 个空格的缩进 (修复 <Step> 内容被识别为代码块的问题)

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -208,6 +208,111 @@ export class PandocPdfService {
   }
 
   /**
+   * Strip PascalCase JSX component tags (`<Foo ... />`, `<Foo>`, `</Foo>`)
+   * using a brace-aware scanner that correctly skips over nested JSX
+   * inside attribute values like `<Tag attr={<Inner />} />`.
+   *
+   * Rules:
+   * - Tag name must start with an uppercase letter (JSX convention).
+   * - Inside the attribute list, `{...}` expressions are tracked with a
+   *   depth counter, so any `>` encountered while `depth > 0` is ignored.
+   * - String attribute values (`"..."` / `'...'`) are skipped verbatim.
+   * - If no closing `>` is found before end of input, the scanner leaves
+   *   the text untouched and moves on.
+   *
+   * Does not attempt to handle backtick template literals inside JSX
+   * attributes; those are exceedingly rare in scraped MDX and can be
+   * added if a real case shows up.
+   *
+   * @param {string} content
+   * @returns {string}
+   * @private
+   */
+  _stripPascalCaseJsxTags(content) {
+    if (!content) return content;
+
+    const len = content.length;
+    let out = '';
+    let i = 0;
+
+    while (i < len) {
+      const ch = content[i];
+      if (ch !== '<') {
+        out += ch;
+        i++;
+        continue;
+      }
+
+      // Possible tag start. Allow `</` closing form.
+      let nameStart = i + 1;
+      if (nameStart < len && content[nameStart] === '/') nameStart++;
+
+      const nameChar = content[nameStart];
+      if (!nameChar || nameChar < 'A' || nameChar > 'Z') {
+        // Not a PascalCase JSX tag — keep the `<` as-is.
+        out += ch;
+        i++;
+        continue;
+      }
+
+      // Scan the tag name (letters/digits).
+      let afterName = nameStart + 1;
+      while (
+        afterName < len &&
+        ((content[afterName] >= 'A' && content[afterName] <= 'Z') ||
+          (content[afterName] >= 'a' && content[afterName] <= 'z') ||
+          (content[afterName] >= '0' && content[afterName] <= '9'))
+      ) {
+        afterName++;
+      }
+
+      // Scan attributes until balanced `>` is found.
+      let depth = 0;
+      let inString = false;
+      let stringChar = '';
+      let end = -1;
+      for (let m = afterName; m < len; m++) {
+        const c = content[m];
+        const prev = m > 0 ? content[m - 1] : '';
+
+        if (inString) {
+          if (c === stringChar && prev !== '\\') {
+            inString = false;
+          }
+          continue;
+        }
+
+        if (c === '"' || c === "'") {
+          inString = true;
+          stringChar = c;
+          continue;
+        }
+
+        if (c === '{') {
+          depth++;
+        } else if (c === '}') {
+          if (depth > 0) depth--;
+        } else if (c === '>' && depth === 0) {
+          end = m;
+          break;
+        }
+      }
+
+      if (end === -1) {
+        // Malformed / unterminated — skip past `<` only.
+        out += ch;
+        i++;
+        continue;
+      }
+
+      // Drop the entire tag [i .. end].
+      i = end + 1;
+    }
+
+    return out;
+  }
+
+  /**
    * 清理 Markdown 内容，修复 Pandoc 不支持的语法
    * @param {string} content
    * @returns {string}
@@ -281,10 +386,16 @@ export class PandocPdfService {
       }
     );
 
-    // Remove any remaining JSX/MDX component tags (PascalCase = JSX convention)
-    // Strips only the tags, inner content is preserved
+    // Remove any remaining JSX/MDX component tags (PascalCase = JSX convention).
+    // Strips only the tags, inner content is preserved.
     // e.g. <Frame><img .../></Frame> -> <img .../>
-    cleaned = cleaned.replace(/<\/?[A-Z][A-Za-z]*(?:\s[^>]*)?\/?>/g, '');
+    //
+    // Uses a brace-aware scanner rather than a plain regex because JSX
+    // attributes can embed nested JSX, e.g.
+    //   <Experiment treatment={<InstallConfigurator />} />
+    // A naive `<[A-Z]...[^>]*>` would stop at the inner `/>` and leave
+    // `} />` behind as garbage prose.
+    cleaned = this._stripPascalCaseJsxTags(cleaned);
 
     // 0.1 修复缩进
     // 移除 2-4 个空格的缩进 (修复 <Step> 内容被识别为代码块的问题)

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -322,6 +322,38 @@ describe('PandocPdfService', () => {
       expect(result).toContain('suffix text');
     });
 
+    it('should strip JSX tag whose attribute value is a nested JSX element', () => {
+      // Regression: `<Experiment treatment={<InstallConfigurator />} />`
+      // A naive `<[A-Z]...[^>]*>` stops at the inner `/>` and leaves
+      // `} />` behind as prose. The brace-aware scanner must drop the
+      // whole outer tag.
+      const input = [
+        'before',
+        '',
+        '<Experiment flag="quickstart-install-configurator" treatment={<InstallConfigurator />} />',
+        '',
+        'after',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toContain('Experiment');
+      expect(result).not.toContain('InstallConfigurator');
+      expect(result).not.toContain('} />');
+      expect(result).not.toContain('/>');
+      expect(result).toContain('before');
+      expect(result).toContain('after');
+    });
+
+    it('should strip JSX tag with multiple nested JSX attribute values', () => {
+      const input =
+        '<Card icon={<Icon name="book" />} action={<Button label="Go" />}>Content</Card>';
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toContain('<Card');
+      expect(result).not.toContain('</Card');
+      expect(result).not.toContain('<Icon');
+      expect(result).not.toContain('<Button');
+      expect(result).toContain('Content');
+    });
+
     it('should strip MDX export containing embedded CSS template literal', () => {
       // Regression: CSS inside a JS template literal has bare `}` at column 0
       // (end of each CSS rule). Earlier regex stopped at the first such `}`

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -322,6 +322,43 @@ describe('PandocPdfService', () => {
       expect(result).toContain('suffix text');
     });
 
+    it('should strip MDX export containing embedded CSS template literal', () => {
+      // Regression: CSS inside a JS template literal has bare `}` at column 0
+      // (end of each CSS rule). Earlier regex stopped at the first such `}`
+      // and left the rest of the CSS leaking into the PDF. The real closer is
+      // always `};` with a semicolon.
+      const input = [
+        '# Quickstart',
+        '',
+        'export const InstallConfigurator = () => {',
+        '  const STYLES = `',
+        '.cc-ic {',
+        '  --ic-slate: #141413;',
+        '  font-size: 14px;',
+        '}',
+        '.dark .cc-ic {',
+        '  --ic-slate: #f0eee6;',
+        '}',
+        '.cc-ic-tab-strip {',
+        '  display: inline-flex;',
+        '}',
+        '`;',
+        '  return <div className="cc-ic">hi</div>;',
+        '};',
+        '',
+        '## Step 1',
+        'Body.',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toContain('cc-ic');
+      expect(result).not.toContain('--ic-slate');
+      expect(result).not.toContain('inline-flex');
+      expect(result).not.toContain('export const InstallConfigurator');
+      expect(result).toContain('# Quickstart');
+      expect(result).toContain('## Step 1');
+      expect(result).toContain('Body.');
+    });
+
     it('should strip multiple consecutive MDX export blocks', () => {
       const input = [
         'export const A = () => {',

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -453,6 +453,28 @@ describe('PandocPdfService', () => {
       const result = service._cleanMarkdownContent(input);
       expect(result).toBe(expected);
     });
+
+    it('should preserve nested code fences when outer uses more backticks (regex fallback)', () => {
+      // Regression: the regex fence splitter must match closing delimiter to
+      // the opener's character AND length. A 3-backtick line inside a
+      // 4-backtick block must NOT end the protected region.
+      const input = [
+        '````markdown',
+        'export const SHOULD_SURVIVE = true;',
+        '```bash',
+        'export VAR=1',
+        '```',
+        '````',
+        '',
+        "import Leak from './leak';",
+      ].join('\n');
+      const result = service._stripMdxModuleDeclarations(input);
+      // The export inside the 4-backtick block must survive
+      expect(result).toContain('export const SHOULD_SURVIVE = true;');
+      expect(result).toContain('export VAR=1');
+      // The import outside the fence must be stripped
+      expect(result).not.toMatch(/^import Leak/m);
+    });
   });
 
   describe('_runPandoc', () => {

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -279,6 +279,104 @@ describe('PandocPdfService', () => {
       expect(result).toBe('> Some text\n>\n> - item 1');
     });
 
+    it('should strip multi-line MDX export const declarations', () => {
+      const input = [
+        '# Quickstart',
+        '',
+        'export const InstallConfigurator = () => {',
+        "  const TERM = { mac: 'curl -fsSL https://claude.ai/install.sh | bash' };",
+        '  return <div>stuff</div>;',
+        '};',
+        '',
+        '## Step 1',
+        'Real content.',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toContain('export const InstallConfigurator');
+      expect(result).not.toContain('const TERM');
+      expect(result).toContain('# Quickstart');
+      expect(result).toContain('## Step 1');
+      expect(result).toContain('Real content.');
+    });
+
+    it('should strip MDX export that uses template literals with backticks', () => {
+      // Reproduces the quickstart.md Experiment helper shape that triggered
+      // the CI LaTeX error: backtick template literals confused pandoc into
+      // opening math mode inside escaped prose.
+      const input = [
+        'prefix text',
+        '',
+        'export const Experiment = ({flag, treatment, children}) => {',
+        '  const ajsMatch = document.cookie.match(/(?:^|; )ajs=([^;]+)/);',
+        '  const vid = decodeURIComponent(ajsMatch[1]).replace(/^"|"$/g, "");',
+        '  document.cookie = `ajs=${vid}; domain=.claude.com`;',
+        '  return treatment;',
+        '};',
+        '',
+        'suffix text',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toContain('export const Experiment');
+      expect(result).not.toContain('document.cookie');
+      expect(result).toContain('prefix text');
+      expect(result).toContain('suffix text');
+    });
+
+    it('should strip multiple consecutive MDX export blocks', () => {
+      const input = [
+        'export const A = () => {',
+        '  return 1;',
+        '};',
+        '',
+        'export const B = () => {',
+        '  return 2;',
+        '};',
+        '',
+        '# Real title',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toContain('export const A');
+      expect(result).not.toContain('export const B');
+      expect(result).toContain('# Real title');
+    });
+
+    it('should preserve export/import lines inside fenced code blocks', () => {
+      // Python example containing `import`, and shell `export VAR=...` must
+      // survive because they are inside fenced code blocks.
+      const input = [
+        '# Example',
+        '',
+        '```python',
+        'import json',
+        'import sys',
+        'print(json.dumps({"ok": True}))',
+        '```',
+        '',
+        '```bash',
+        'export MAX_TOKENS=50000',
+        'claude',
+        '```',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).toContain('import json');
+      expect(result).toContain('import sys');
+      expect(result).toContain('export MAX_TOKENS=50000');
+    });
+
+    it('should strip top-level MDX import statements', () => {
+      const input = [
+        "import Foo from '@site/components/Foo';",
+        'import Bar from "./Bar";',
+        '',
+        '# Page title',
+        'body',
+      ].join('\n');
+      const result = service._cleanMarkdownContent(input);
+      expect(result).not.toMatch(/^import\s/m);
+      expect(result).toContain('# Page title');
+      expect(result).toContain('body');
+    });
+
     it('should handle mixed backtick lengths correctly', () => {
       const input =
         '````markdown theme={null}\n' + '```bash\n' + 'echo "hello"\n' + '```\n' + '````';


### PR DESCRIPTION
## Summary
- Fixes CI failure on the `Generate PDF` workflow for the `claude-code` target where Pandoc/XeLaTeX aborted with `Extra }, or forgotten $.` / `LaTeX Error: Something's wrong--perhaps a missing \item` at `\end{quote}` (runs [#24056750974](https://github.com/xrf-9527/documentation-pdf-scraper/actions/runs/24056750974)).
- Root cause: MDX pages scraped from `code.claude.com/docs` (e.g. `quickstart.md`, `claude-directory.md`, `context-window.md`, `mcp.md`) contain top-level `export const X = () => { ... };` helpers that are meant to be executed by the MDX runtime. They leak into the raw markdown and Pandoc renders them as prose, so JS template literal backticks and escaped regex `\(` open inline math mode, breaking the LaTeX build.
- Adds `_stripMdxModuleDeclarations` which splits markdown by fenced code blocks and, in non-fenced segments, strips top-level `export (const|default|function|let|var) ... };`, single-line exports, and `import X from '...';` statements. Runs first in `_cleanMarkdownContent` so column-0 `};` closers are still matchable before indentation normalization. Python `import` and shell `export VAR=...` inside fenced code blocks are preserved.

## Test plan
- [x] `make docs-claude && make clean && make run` (local, Pandoc + XeLaTeX) — batch PDF now generated successfully (~2.1 MB) with no LaTeX errors
- [x] `make test` — 662/662 tests pass (5 new regression tests: multi-line exports, backtick template literals, consecutive blocks, fenced-code preservation, top-level imports)
- [x] `make lint` — clean