### PR TITLE
fix(ci): install latest Pandoc and sanitize blockquote headings

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -59,11 +59,10 @@ jobs:
           enable-cache: true
           python-version: '3.10'
 
-      - name: Install system dependencies
+      - name: Install LaTeX and fonts
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            pandoc \
             texlive-xetex \
             texlive-fonts-recommended \
             texlive-fonts-extra \
@@ -72,6 +71,11 @@ jobs:
             fonts-noto-cjk \
             fonts-lmodern \
             lmodern
+
+      - name: Install latest Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+        with:
+          pandoc-version: 'latest'
 
       - name: Install project dependencies
         run: |

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -620,7 +620,36 @@ export class PandocPdfService {
     // but older Pandoc (e.g. Ubuntu 24.04 ships 3.1.x) does not, which causes
     // `LaTeX Error: Something's wrong--perhaps a missing \item` at `\end{quote}`.
     // Bold preserves visual emphasis without triggering quote+section nesting.
-    cleaned = cleaned.replace(/^(>\s*)#{1,6}\s+(.+?)\s*$/gm, '$1**$2**');
+    //
+    // Fence-aware: skip lines inside fenced code blocks (with optional `> `
+    // blockquote prefix) so markdown examples that show heading syntax inside
+    // ` ``` ... ``` ` blocks are not corrupted. Closing fences must use the
+    // same character (` or ~) and at least as many repetitions as the opener
+    // (CommonMark spec).
+    {
+      const lines = cleaned.split('\n');
+      let inFence = false;
+      let fenceChar = '';
+      let fenceCount = 0;
+      for (let i = 0; i < lines.length; i++) {
+        const fenceMatch = lines[i].match(/^>?\s*(`{3,}|~{3,})/);
+        if (fenceMatch) {
+          const fc = fenceMatch[1][0];
+          const fcCount = fenceMatch[1].length;
+          if (!inFence) {
+            inFence = true;
+            fenceChar = fc;
+            fenceCount = fcCount;
+          } else if (fc === fenceChar && fcCount >= fenceCount) {
+            inFence = false;
+          }
+          continue;
+        }
+        if (inFence) continue;
+        lines[i] = lines[i].replace(/^(>\s*)#{1,6}\s+(.+?)\s*$/, '$1**$2**');
+      }
+      cleaned = lines.join('\n');
+    }
 
     // 5. 将图片 URL 中的 fm=webp 替换为 fm=png（LaTeX 不支持 webp 格式）
     cleaned = cleaned.replace(/fm=webp/g, 'fm=png');

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -615,6 +615,13 @@ export class PandocPdfService {
     // e.g. "> text\n> - item" -> "> text\n>\n> - item"
     cleaned = cleaned.replace(/^(>.*[^\s-*].*)\n(>\s*[-*]\s+\S)/gm, '$1\n>\n$2');
 
+    // 4c. Convert ATX headings inside blockquotes to bold text.
+    // Pandoc 3.9+ inserts `\mbox{}%` before `\subsection` inside `\begin{quote}`,
+    // but older Pandoc (e.g. Ubuntu 24.04 ships 3.1.x) does not, which causes
+    // `LaTeX Error: Something's wrong--perhaps a missing \item` at `\end{quote}`.
+    // Bold preserves visual emphasis without triggering quote+section nesting.
+    cleaned = cleaned.replace(/^(>\s*)#{1,6}\s+(.+?)\s*$/gm, '$1**$2**');
+
     // 5. 将图片 URL 中的 fm=webp 替换为 fm=png（LaTeX 不支持 webp 格式）
     cleaned = cleaned.replace(/fm=webp/g, 'fm=png');
 


### PR DESCRIPTION
## Summary

CI was failing with `LaTeX Error: Something's wrong--perhaps a missing \item` at `\end{quote}` while local builds succeeded. Root cause is a Pandoc version mismatch between local and CI:

- **Local**: Pandoc 3.9.0.2 (Homebrew) — emits \`\mbox{}%\` before \`\subsection\` inside \`\begin{quote}\`
- **CI**: Pandoc 3.1.3 (Ubuntu 24.04 apt) — does not emit \`\mbox{}%\`, so the \`> ## Documentation Index\` blockquote prefix on every scraped page triggers the LaTeX error

Failing run: https://github.com/xrf-9527/documentation-pdf-scraper/actions/runs/24072420081/job/70212401820

## Changes

- **\`.github/workflows/generate-pdf.yml\`**: Replace \`apt-get install pandoc\` with \`r-lib/actions/setup-pandoc@v2\` (\`pandoc-version: 'latest'\`). LaTeX/fonts still come from apt — they're stable and the bug is not in the LaTeX core.
- **\`src/services/pandocPdfService.js\`**: In \`_cleanMarkdownContent\`, convert ATX headings inside blockquotes (\`> ## Title\`) to bold text (\`> **Title**\`). Defense-in-depth — if the action ever falls back or a future Pandoc version regresses, the source-level cleanup still prevents this class of error.

## Test plan

- [x] Local Pandoc PDF generation still succeeds with the cleaning rule applied
- [x] \`make lint\` passes
- [ ] CI PDF generation succeeds on this PR