### PR TITLE
fix: strip script/style/noscript in turndown to unblock Pandoc PDF

### DIFF
--- a/src/services/markdownService.js
+++ b/src/services/markdownService.js
@@ -22,6 +22,14 @@ export class MarkdownService {
 
     this.turndown = new TurndownService(turndownOptions);
 
+    // 剥离非正文且可能污染 LaTeX 的元素。
+    // 背景：某些站点（例如 developers.openai.com 的 Next.js 构建）会把
+    // 压缩后的 JavaScript 直接嵌入正文容器内的 <script> 标签，其中裸露的
+    // `&` 字符会让 Pandoc → XeLaTeX 以 `Misplaced alignment tab character &.`
+    // 报错并中止 PDF 生成。CSS 字面量同理。统一在此剥离，使 Markdown 工作流
+    // 无需依赖 pdfStyleService（后者仅在 enablePDFStyleProcessing=true 时生效）。
+    this.turndown.remove(['script', 'noscript', 'style', 'template']);
+
     // 使用 `*text*` 而不是 `_text_` 来表示 HTML <em>/<i> 强调，
     // 这样生成的 Markdown 更符合 Pandoc / CommonMark 对“词内部强调优先使用 *”的最佳实践，
     // 避免在中英文混排场景下由下划线强调带来的歧义。

--- a/tests/services/markdownService.test.js
+++ b/tests/services/markdownService.test.js
@@ -74,6 +74,30 @@ describe('MarkdownService', () => {
     expect(duplicateItalic).toBe(false);
   });
 
+  test('convertHtmlToMarkdown 应该剥离 <script>/<style>/<noscript> 内容', () => {
+    // Regression: OpenAI 文档页面的 Next.js 构建会在正文 DOM 中嵌入 <script>，
+    // 其压缩后的 JS 含有裸露 `&` 字符，会让 Pandoc/XeLaTeX 以
+    // `Misplaced alignment tab character &.` 报错并中止 PDF 生成。
+    // 这里确保 script/style/noscript 的内容完全不进入 Markdown。
+    const service = new MarkdownService({ logger });
+    const html = [
+      '<p>Before</p>',
+      '<script>window._(HY||(e=>{let t=e=>e&1;}));</script>',
+      '<style>.foo { color: red; }</style>',
+      '<noscript>Please enable JS</noscript>',
+      '<p>After</p>',
+    ].join('');
+
+    const markdown = service.convertHtmlToMarkdown(html);
+
+    expect(markdown).toContain('Before');
+    expect(markdown).toContain('After');
+    expect(markdown).not.toContain('window._');
+    expect(markdown).not.toContain('window.\\_');
+    expect(markdown).not.toContain('color: red');
+    expect(markdown).not.toContain('Please enable JS');
+  });
+
   test('代码块应保留语言标识', () => {
     const service = new MarkdownService({ logger });
     const html = '<pre><code class="language-js">const x = 1;</code></pre>';


### PR DESCRIPTION
## Summary
- Fixes CI failure in [Generate PDF run 24123143230](https://github.com/xrf-9527/documentation-pdf-scraper/actions/runs/24123143230) where Pandoc/XeLaTeX aborted with `Misplaced alignment tab character &.` at exit code 43.
- Root cause: Next.js-built docs (developers.openai.com/codex) embed minified JavaScript inside the scraped content container. Turndown's default behavior keeps `<script>` text as Markdown, and bare `&` in that JS trips XeLaTeX's alignment-tab handling.
- `pdfStyleService` already removes `<script>`, but only when `enablePDFStyleProcessing=true`; `doc-targets/openai-docs.json` has it disabled, so the Markdown workflow was exposed.
- Fix at the Turndown layer so both `extractAndConvertPage` and `convertHtmlToMarkdown` are covered regardless of the style-processing toggle.

## Test plan
- [x] Added regression test in `tests/services/markdownService.test.js` using the exact JS fragment from the failing CI log.
- [x] `make clean && make test` — 667/667 passing.
- [x] `make lint` — 0 errors.
- [ ] Re-run `Generate PDF (openai)` workflow after merge to confirm CI green.