### PR TITLE
[codex] fix PDF image handling for generated docs

### DIFF
--- a/doc-targets/openclaw-zh-cn.json
+++ b/doc-targets/openclaw-zh-cn.json
@@ -33,6 +33,7 @@
     "urlSuffix": ".md"
   },
   "targetUrls": [
+    "https://docs.openclaw.ai/zh-CN/AGENTS",
     "https://docs.openclaw.ai/zh-CN/automation/cron-jobs",
     "https://docs.openclaw.ai/zh-CN/automation/hooks",
     "https://docs.openclaw.ai/zh-CN/brave-search",
@@ -138,6 +139,7 @@
     "https://docs.openclaw.ai/zh-CN/gateway/background-process",
     "https://docs.openclaw.ai/zh-CN/gateway/bonjour",
     "https://docs.openclaw.ai/zh-CN/gateway/bridge-protocol",
+    "https://docs.openclaw.ai/zh-CN/gateway/cli-backends",
     "https://docs.openclaw.ai/zh-CN/gateway/configuration",
     "https://docs.openclaw.ai/zh-CN/gateway/configuration-examples",
     "https://docs.openclaw.ai/zh-CN/gateway/discovery",
@@ -164,9 +166,11 @@
     "https://docs.openclaw.ai/zh-CN/gateway/troubleshooting",
     "https://docs.openclaw.ai/zh-CN/help/debugging",
     "https://docs.openclaw.ai/zh-CN/help/environment",
+    "https://docs.openclaw.ai/zh-CN/help/faq",
     "https://docs.openclaw.ai/zh-CN/help",
     "https://docs.openclaw.ai/zh-CN/help/scripts",
     "https://docs.openclaw.ai/zh-CN/help/testing",
+    "https://docs.openclaw.ai/zh-CN/help/troubleshooting",
     "https://docs.openclaw.ai/zh-CN",
     "https://docs.openclaw.ai/zh-CN/install/ansible",
     "https://docs.openclaw.ai/zh-CN/install/bun",

--- a/src/core/scraper.js
+++ b/src/core/scraper.js
@@ -1297,7 +1297,7 @@ export class Scraper extends EventEmitter {
           if (this.config.markdownSource?.enabled) {
             const mdSource = await this._fetchMarkdownSource(url);
             if (mdSource) {
-              markdownContent = mdSource.content;
+              markdownContent = this.markdownService.normalizeResourceUrls(mdSource.content, url);
               sourceTitle = mdSource.title;
               this.logger.info('使用直接获取的 Markdown 源文件', {
                 url,

--- a/src/services/markdownService.js
+++ b/src/services/markdownService.js
@@ -84,6 +84,121 @@ export class MarkdownService {
   }
 
   /**
+   * 将相对资源 URL 规范化为绝对 URL，避免 Pandoc 在 PDF 阶段把站点内资源
+   * 误当成本地文件路径处理（例如 `/images/...`）。
+   *
+   * @param {string} markdown
+   * @param {string} pageUrl
+   * @returns {string}
+   */
+  normalizeResourceUrls(markdown, pageUrl) {
+    if (!markdown || typeof markdown !== 'string' || !pageUrl) {
+      return markdown;
+    }
+
+    let normalized = markdown;
+
+    // Markdown links/images: ![alt](/img.png) / [text](/guide)
+    normalized = normalized.replace(
+      /(!?\[[^\]]*]\(\s*)(<)?((?:\/{1,2}|\.{1,2}\/)[^)\s>]+(?:\?[^)\s>]*)?(?:#[^)\s>]*)?)(>)?((?:\s+["'][^"']*["'])?\s*\))/g,
+      (match, prefix, openBracket = '', target, closeBracket = '', suffix) => {
+        const resolved = this._resolveResourceUrl(target, pageUrl);
+        return resolved ? `${prefix}${openBracket}${resolved}${closeBracket}${suffix}` : match;
+      }
+    );
+
+    // Raw HTML img/a tags embedded in markdown.
+    normalized = normalized.replace(
+      /(<(?:img|a)\b[^>]*?\b(?:src|href)=["'])([^"']+)(["'][^>]*>)/gi,
+      (match, prefix, target, suffix) => {
+        const resolved = this._resolveResourceUrl(target, pageUrl);
+        return resolved ? `${prefix}${resolved}${suffix}` : match;
+      }
+    );
+
+    // Raw HTML source tags with srcset, e.g. <source srcset="/foo.webp 1x, /bar.webp 2x">
+    normalized = normalized.replace(
+      /(<source\b[^>]*?\bsrcset=["'])([^"']+)(["'][^>]*>)/gi,
+      (match, prefix, srcset, suffix) => {
+        const resolved = this._resolveSrcset(srcset, pageUrl);
+        return resolved ? `${prefix}${resolved}${suffix}` : match;
+      }
+    );
+
+    return normalized;
+  }
+
+  /**
+   * 将单个相对 URL 解析为绝对 URL。
+   *
+   * @param {string} target
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _resolveResourceUrl(target, pageUrl) {
+    if (!target || typeof target !== 'string' || !pageUrl) {
+      return target;
+    }
+
+    const trimmed = target.trim();
+    if (!trimmed) return target;
+
+    // 已经是绝对 URL、锚点、内联数据或非网页协议时不处理。
+    if (/^(?:[a-z][a-z\d+.-]*:|#)/i.test(trimmed)) {
+      return trimmed;
+    }
+
+    const isRelativePath =
+      trimmed.startsWith('/') ||
+      trimmed.startsWith('./') ||
+      trimmed.startsWith('../') ||
+      trimmed.startsWith('//');
+
+    if (!isRelativePath) {
+      return trimmed;
+    }
+
+    try {
+      return new URL(trimmed, pageUrl).toString();
+    } catch (error) {
+      this.logger?.debug?.('资源 URL 规范化失败，保留原值', {
+        pageUrl,
+        target: trimmed,
+        error: error.message,
+      });
+      return trimmed;
+    }
+  }
+
+  /**
+   * 解析 srcset 中的多个资源 URL。
+   *
+   * @param {string} srcset
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _resolveSrcset(srcset, pageUrl) {
+    if (!srcset || typeof srcset !== 'string') {
+      return srcset;
+    }
+
+    return srcset
+      .split(',')
+      .map((entry) => {
+        const trimmed = entry.trim();
+        if (!trimmed) return trimmed;
+
+        const [target, ...descriptors] = trimmed.split(/\s+/);
+        const resolved = this._resolveResourceUrl(target, pageUrl);
+
+        return [resolved, ...descriptors].join(' ').trim();
+      })
+      .join(', ');
+  }
+
+  /**
    * 规范化图像与图注：
    * - 如果某行是斜体（例如 _Figure 1: ..._ 或 *Figure 1: ...*），
    * - 且其前一行（忽略空行）是 Markdown 图片行，并且两者文本几乎相同，
@@ -169,7 +284,8 @@ export class MarkdownService {
 
     try {
       const rawMarkdown = this.turndown.turndown(html);
-      const markdown = this._normalizeFigureCaptions(rawMarkdown);
+      const normalizedMarkdown = this.normalizeResourceUrls(rawMarkdown, options.pageUrl);
+      const markdown = this._normalizeFigureCaptions(normalizedMarkdown);
       this.logger?.debug?.('HTML 转 Markdown 完成', {
         length: markdown.length,
         ...options.debugMeta,
@@ -189,6 +305,7 @@ export class MarkdownService {
    * @returns {Promise<string>}
    */
   async extractAndConvertPage(page, selector) {
+    const pageUrl = typeof page.url === 'function' ? page.url() : undefined;
     const { html, svgCount } = await page.evaluate((contentSelector) => {
       const container = document.querySelector(contentSelector);
       if (!container) {
@@ -245,7 +362,10 @@ export class MarkdownService {
       svgCount,
     });
 
-    return this.convertHtmlToMarkdown(html, { debugMeta: { svgCount } });
+    return this.convertHtmlToMarkdown(html, {
+      debugMeta: { svgCount },
+      pageUrl,
+    });
   }
 
   /**

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -535,6 +535,68 @@ export class PandocPdfService {
   }
 
   /**
+   * 检查图片 URL 是否是 XeLaTeX/Pandoc 不稳定的格式。
+   * 目前重点处理 webp/avif；如果 URL 已显式请求 png/jpg/jpeg，则认为安全。
+   *
+   * @param {string} url
+   * @returns {boolean}
+   * @private
+   */
+  _isPdfUnsafeImageUrl(url) {
+    if (!url || typeof url !== 'string') return false;
+
+    const lower = url.trim().toLowerCase();
+    if (!lower) return false;
+
+    if (/[?&](?:fm|format)=(?:png|jpg|jpeg|pdf)(?:[&#]|$)/.test(lower)) {
+      return false;
+    }
+
+    return /\.(?:webp|avif)(?:$|[?#])/i.test(lower);
+  }
+
+  /**
+   * 将 PDF 不安全的图片语法降级为普通超链接，避免 Pandoc/XeLaTeX 直接失败。
+   *
+   * @param {string} content
+   * @returns {string}
+   * @private
+   */
+  _downgradePdfUnsafeImages(content) {
+    if (!content) return content;
+
+    let downgraded = content;
+
+    downgraded = downgraded.replace(
+      /!\[([^\]]*)\]\((<)?([^)\n>]+)(>)?((?:\s+["'][^"']*["'])?\s*)\)/g,
+      (match, altText = '', openBracket = '', url, closeBracket = '') => {
+        if (!this._isPdfUnsafeImageUrl(url)) {
+          return match;
+        }
+
+        const label = altText.trim() || 'Image';
+        return `[${label}](${openBracket}${url}${closeBracket})`;
+      }
+    );
+
+    downgraded = downgraded.replace(
+      /<img\b([^>]*?)src=(["'])([^"']+)\2([^>]*)>/gi,
+      (match, before, _quote, src, after) => {
+        if (!this._isPdfUnsafeImageUrl(src)) {
+          return match;
+        }
+
+        const attrs = `${before} ${after}`;
+        const altMatch = attrs.match(/\balt=(["'])(.*?)\1/i);
+        const label = altMatch?.[2]?.trim() || 'Image';
+        return `[${label}](${src})`;
+      }
+    );
+
+    return downgraded;
+  }
+
+  /**
    * 清理 Markdown 内容，修复 Pandoc 不支持的语法
    * @param {string} content
    * @returns {string}
@@ -653,6 +715,9 @@ export class PandocPdfService {
 
     // 5. 将图片 URL 中的 fm=webp 替换为 fm=png（LaTeX 不支持 webp 格式）
     cleaned = cleaned.replace(/fm=webp/g, 'fm=png');
+
+    // 6. 对仍然是 PDF 不安全格式的图片做降级，避免 Pandoc/XeLaTeX 直接失败。
+    cleaned = this._downgradePdfUnsafeImages(cleaned);
 
     return cleaned;
   }

--- a/tests/core/scraper.test.js
+++ b/tests/core/scraper.test.js
@@ -49,6 +49,7 @@ describe('Scraper', () => {
       },
       fileService: {
         ensureDirectory: vi.fn(),
+        writeText: vi.fn(),
       },
       pathService: {
         getPdfPath: vi.fn().mockReturnValue('./pdfs/001-page.pdf'),
@@ -119,6 +120,9 @@ describe('Scraper', () => {
           printBackground: true,
         }),
       },
+      markdownService: null,
+      translationService: null,
+      markdownToPdfService: null,
     };
 
     scraper = new Scraper(mockDependencies);
@@ -459,6 +463,45 @@ describe('Scraper', () => {
       await scraper.scrapePage(testUrl, testIndex);
 
       expect(mockDependencies.stateManager.save).toHaveBeenCalled();
+    });
+
+    it('should normalize relative asset URLs when using markdown source workflow', async () => {
+      scraper.config.markdown = { enabled: true };
+      scraper.config.markdownPdf = { enabled: true, batchMode: true };
+      scraper.config.markdownSource = { enabled: true };
+
+      mockDependencies.markdownService = {
+        normalizeResourceUrls: vi.fn((content) =>
+          content.replace('/images/app.png', 'https://example.com/images/app.png')
+        ),
+        extractAndConvertPage: vi.fn(),
+        addFrontmatter: vi.fn((content) => content),
+      };
+      mockDependencies.markdownToPdfService = {
+        convertContentToPdf: vi.fn(),
+      };
+      mockDependencies.translationService = null;
+
+      scraper.markdownService = mockDependencies.markdownService;
+      scraper.markdownToPdfService = mockDependencies.markdownToPdfService;
+      scraper.translationService = null;
+
+      vi.spyOn(scraper, '_fetchMarkdownSource').mockResolvedValue({
+        content: '![App](/images/app.png)',
+        title: 'Page Title',
+      });
+
+      const result = await scraper.scrapePage(testUrl, testIndex);
+
+      expect(result.status).toBe('success');
+      expect(mockDependencies.markdownService.normalizeResourceUrls).toHaveBeenCalledWith(
+        '![App](/images/app.png)',
+        testUrl
+      );
+      expect(mockDependencies.fileService.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('.md'),
+        '![App](https://example.com/images/app.png)'
+      );
     });
   });
 

--- a/tests/services/markdownService.test.js
+++ b/tests/services/markdownService.test.js
@@ -25,6 +25,39 @@ describe('MarkdownService', () => {
     expect(markdown).toContain('Content');
   });
 
+  test('convertHtmlToMarkdown 应该将根相对图片 URL 规范为绝对地址', () => {
+    const service = new MarkdownService({ logger });
+    const html = '<p><img src="/images/hero.png" alt="Hero"></p>';
+
+    const markdown = service.convertHtmlToMarkdown(html, {
+      pageUrl: 'https://developers.openai.com/codex/overview',
+    });
+
+    expect(markdown).toContain('![Hero](https://developers.openai.com/images/hero.png)');
+  });
+
+  test('normalizeResourceUrls 应该处理 markdown 链接、图片和 srcset', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '![Screenshot](/images/app.webp)',
+      '[Guide](/guides/quickstart)',
+      '<img src="./relative.png" alt="Relative">',
+      '<source srcset="/img-1x.webp 1x, ../img-2x.webp 2x">',
+    ].join('\n');
+
+    const result = service.normalizeResourceUrls(
+      markdown,
+      'https://developers.openai.com/codex/reference/page'
+    );
+
+    expect(result).toContain('![Screenshot](https://developers.openai.com/images/app.webp)');
+    expect(result).toContain('[Guide](https://developers.openai.com/guides/quickstart)');
+    expect(result).toContain('<img src="https://developers.openai.com/codex/reference/relative.png"');
+    expect(result).toContain(
+      '<source srcset="https://developers.openai.com/img-1x.webp 1x, https://developers.openai.com/codex/img-2x.webp 2x">'
+    );
+  });
+
   test('convertHtmlToMarkdown 应该使用 * 而不是 _ 作为强调符号', () => {
     const service = new MarkdownService({ logger });
     const html = '<p>One person said that iterating with Claude has been <em>more</em> fun.</p>';
@@ -157,8 +190,9 @@ describe('MarkdownService', () => {
   test('extractAndConvertPage 应该调用 page.evaluate 并返回 Markdown', async () => {
     const service = new MarkdownService({ logger });
     const page = {
+      url: vi.fn().mockReturnValue('https://developers.openai.com/codex/intro'),
       evaluate: vi.fn(async () => ({
-        html: '<h1>Title</h1><p>Body</p>',
+        html: '<h1>Title</h1><p><img src="/images/body.png" alt="Body"></p>',
         svgCount: 0,
       })),
     };
@@ -167,6 +201,6 @@ describe('MarkdownService', () => {
 
     expect(page.evaluate).toHaveBeenCalledTimes(1);
     expect(markdown).toContain('Title');
-    expect(markdown).toContain('Body');
+    expect(markdown).toContain('![Body](https://developers.openai.com/images/body.png)');
   });
 });

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -409,6 +409,29 @@ describe('PandocPdfService', () => {
       expect(result).toContain('# Real title');
     });
 
+    it('should downgrade webp markdown images to plain links', () => {
+      const input = '![App screenshot](https://developers.openai.com/images/app.webp)';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe('[App screenshot](https://developers.openai.com/images/app.webp)');
+    });
+
+    it('should keep images when fm=webp is rewritten to a safe output format', () => {
+      const input =
+        '![Chart](https://cdn.example.com/chart.webp?fm=webp&fit=max)';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe('![Chart](https://cdn.example.com/chart.webp?fm=png&fit=max)');
+    });
+
+    it('should downgrade raw html img tags that point to webp assets', () => {
+      const input =
+        '<img src="https://developers.openai.com/images/app.webp" alt="App screenshot">';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe('[App screenshot](https://developers.openai.com/images/app.webp)');
+    });
+
     it('should preserve export/import lines inside fenced code blocks', () => {
       // Python example containing `import`, and shell `export VAR=...` must
       // survive because they are inside fenced code blocks.


### PR DESCRIPTION
## Summary
- normalize relative markdown/html asset URLs to absolute URLs before writing markdown files
- downgrade PDF-unsafe webp/avif images to plain links so Pandoc/XeLaTeX does not fail hard
- cover both the markdown-source path and the DOM-to-markdown path with regression tests

## Root Cause
OpenAI/Codex docs now emit more root-relative and `.webp` image references. In the batch Pandoc PDF path that caused two failure modes:
- root-relative assets such as `/images/...` were treated as missing local files by Pandoc
- fetched `.webp` assets reached XeLaTeX unchanged and failed with `Cannot determine size of graphic ... (no BoundingBox)`

## Validation
- `make test`
- `make lint`
