### PR TITLE
[codex] ci: switch to official pandoc setup action

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -73,9 +73,9 @@ jobs:
             lmodern
 
       - name: Install latest Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: pandoc/actions/setup@v1.1.1
         with:
-          pandoc-version: 'latest'
+          version: 'latest'
 
       - name: Install project dependencies
         run: |


### PR DESCRIPTION
## Summary
- replace r-lib setup-pandoc with pandoc official setup action
- pin to latest released v1.1.1 action version
- keep installing the latest Pandoc release in the workflow

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/generate-pdf.yml'); puts 'yaml-ok'"\n- verified upstream that r-lib/actions/setup-pandoc@v2 still runs on node20\n- verified pandoc/actions/setup v1.1.1 is the latest official release and is a composite action