### PR TITLE
[codex] fix: let pandoc action resolve latest correctly

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -74,8 +74,6 @@ jobs:
 
       - name: Install latest Pandoc
         uses: pandoc/actions/setup@v1.1.1
-        with:
-          version: 'latest'
 
       - name: Install project dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove the incompatible `version: latest` input from `pandoc/actions/setup`
- rely on the action's documented default behavior to install the latest Pandoc release
- fix the broken Generate PDF workflow introduced by #85

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/generate-pdf.yml'); puts 'yaml-ok'"\n- reproduced the failure on main in run 24716898947 (`release not found`)\n- confirmed the official action treats an empty version as latest