### PR TITLE
fix: improve openai docs pdf readability

### DIFF
--- a/src/core/scraper.js
+++ b/src/core/scraper.js
@@ -1115,9 +1115,18 @@ export class Scraper extends EventEmitter {
 
     // 检查是否已处理
     if (this.stateManager.isProcessed(url)) {
-      this.logger.debug(`跳过已处理的URL: ${url}`);
-      this.progressTracker.skip(url);
-      return { status: 'skipped', reason: 'already_processed' };
+      const hasValidProcessedOutput =
+        typeof this.stateManager.hasValidProcessedOutput === 'function'
+          ? await this.stateManager.hasValidProcessedOutput(url)
+          : true;
+
+      if (hasValidProcessedOutput) {
+        this.logger.debug(`跳过已处理的URL: ${url}`);
+        this.progressTracker.skip(url);
+        return { status: 'skipped', reason: 'already_processed' };
+      }
+
+      this.logger.info('检测到已处理状态但输出缺失，重新爬取当前URL', { url });
     }
 
     const pageId = `scraper-page-${index}`;

--- a/src/services/markdownService.js
+++ b/src/services/markdownService.js
@@ -959,14 +959,27 @@ export class MarkdownService {
     if (!markdown) return markdown;
 
     const strippedPair = markdown.replace(
-      /\[\s*Previous[\s\S]*?]\([^)]+\)\s*\[\s*Next[\s\S]*?]\([^)]+\)\s*$/m,
+      /\[\s*Previous(?:\s|\n)[\s\S]*?]\([^)]+\)\s*\[\s*Next(?:\s|\n)[\s\S]*?]\([^)]+\)\s*$/,
       ''
     );
 
-    return strippedPair.replace(
-      /\[\s*(?:Previous|Next)\s*[\s\S]*?]\([^)]+\)\s*$/m,
-      ''
-    );
+    return strippedPair.replace(/(^|\n)\[\s*([\s\S]*?)\]\([^)]+\)\s*$/, (match, prefix, label) => {
+      const labelLines = String(label)
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      if (labelLines.length === 0) {
+        return match;
+      }
+
+      const firstLine = labelLines[0].toLowerCase();
+      if (firstLine === 'previous' || firstLine === 'next') {
+        return prefix;
+      }
+
+      return match;
+    });
   }
 
   /**

--- a/src/services/markdownService.js
+++ b/src/services/markdownService.js
@@ -307,10 +307,10 @@ export class MarkdownService {
    */
   async extractAndConvertPage(page, selector) {
     const pageUrl = typeof page.url === 'function' ? page.url() : undefined;
-    const { html, svgCount } = await page.evaluate((contentSelector, currentPageUrl) => {
+    const { html, svgCount, openAiModelSections = [] } = await page.evaluate((contentSelector, currentPageUrl) => {
       const container = document.querySelector(contentSelector);
       if (!container) {
-        return { html: '', svgCount: 0 };
+        return { html: '', svgCount: 0, openAiModelSections: [] };
       }
 
       const clone = container.cloneNode(true);
@@ -323,6 +323,7 @@ export class MarkdownService {
           return false;
         }
       })();
+      let openAiModelSections = [];
 
       const getVisibleText = (element) => {
         const textClone = element.cloneNode(true);
@@ -336,6 +337,138 @@ export class MarkdownService {
       };
 
       if (isOpenAiDocsPage) {
+        const decodeAstroValue = (value) => {
+          if (Array.isArray(value) && value.length === 2 && typeof value[0] === 'number') {
+            const [type, payload] = value;
+
+            if (type === 1 && Array.isArray(payload)) {
+              return payload.map(decodeAstroValue);
+            }
+
+            return decodeAstroValue(payload);
+          }
+
+          if (Array.isArray(value)) {
+            return value.map(decodeAstroValue);
+          }
+
+          if (value && typeof value === 'object') {
+            return Object.fromEntries(
+              Object.entries(value).map(([key, nestedValue]) => [key, decodeAstroValue(nestedValue)])
+            );
+          }
+
+          return value;
+        };
+
+        const parseModelCard = (island) => {
+          if (!island) return null;
+
+          let props = {};
+          try {
+            props = decodeAstroValue(JSON.parse(island.getAttribute('props') || '{}'));
+          } catch {
+            props = {};
+          }
+
+          const name = normalizeWhitespace(
+            props.name
+              || island.querySelector('img')?.getAttribute('alt')
+              || island.querySelector('.heading-md, .heading-sm, h3, h4')?.textContent
+              || ''
+          );
+          const description = normalizeWhitespace(
+            props.description || island.querySelector('p')?.textContent || ''
+          );
+          const command = normalizeWhitespace(
+            island.querySelector('.font-mono')?.textContent || (name ? `codex -m ${name}` : '')
+          );
+          const features = Array.isArray(props.data?.features)
+            ? props.data.features
+              .map((feature) => {
+                const title = normalizeWhitespace(feature?.title || '');
+                if (!title) return null;
+
+                return {
+                  title,
+                  value: typeof feature?.value === 'boolean' ? feature.value : normalizeWhitespace(feature?.value || ''),
+                  iconCount: Array.isArray(feature?.icons) ? feature.icons.length : 0,
+                };
+              })
+              .filter(Boolean)
+            : [];
+
+          if (!name && !description && !command && features.length === 0) {
+            return null;
+          }
+
+          return {
+            name,
+            description,
+            command,
+            features,
+          };
+        };
+
+        const collectModelSections = () => {
+          if (!/\/codex\/models\/?$/.test(currentPageUrl || '')) {
+            return [];
+          }
+
+          const sections = [];
+          const sectionHeadings = Array.from(clone.querySelectorAll('h2'));
+
+          sectionHeadings.forEach((heading) => {
+            const headingText = normalizeWhitespace(heading.textContent || '');
+            if (!['Recommended models', 'Alternative models'].includes(headingText)) {
+              return;
+            }
+
+            let grid = heading.nextElementSibling;
+            while (grid && !grid.querySelector?.('astro-island[component-url*="ModelDetails"]')) {
+              if (/^H2$/i.test(grid.tagName)) {
+                grid = null;
+                break;
+              }
+              grid = grid.nextElementSibling;
+            }
+
+            if (!grid) {
+              return;
+            }
+
+            const cards = Array.from(
+              grid.querySelectorAll('astro-island[component-url*="ModelDetails"]')
+            )
+              .map(parseModelCard)
+              .filter(Boolean);
+
+            if (cards.length === 0) {
+              return;
+            }
+
+            const notes = [];
+            let sibling = grid.nextElementSibling;
+            while (sibling && !/^H2$/i.test(sibling.tagName)) {
+              const text = getVisibleText(sibling);
+              if (text && !sibling.querySelector?.('astro-island[component-url*="ModelDetails"]')) {
+                notes.push(text);
+              }
+              sibling = sibling.nextElementSibling;
+            }
+
+            sections.push({
+              heading: headingText,
+              cards,
+              notes,
+            });
+          });
+
+          return sections;
+        };
+
+        openAiModelSections = collectModelSections();
+
         clone
           .querySelectorAll(
             'script, noscript, style, template, [data-page-copy-action], .page-copy-action, [data-anchor-id], [data-codex-screenshot-overlay]'
@@ -479,18 +612,24 @@ export class MarkdownService {
       return {
         html: clone.innerHTML,
         svgCount: svgs.length,
+        openAiModelSections,
       };
     }, selector, pageUrl);
 
     this.logger?.debug?.('从页面提取 HTML 完成', {
       hasContent: !!html,
       svgCount,
+      openAiModelSections: openAiModelSections.length,
     });
 
-    return this.convertHtmlToMarkdown(html, {
+    let markdown = this.convertHtmlToMarkdown(html, {
       debugMeta: { svgCount },
       pageUrl,
     });
+
+    markdown = this._normalizeOpenAiModelsPage(markdown, openAiModelSections, pageUrl);
+
+    return markdown;
   }
 
   /**
@@ -511,15 +650,128 @@ export class MarkdownService {
     sanitized = sanitized.replace(/^\s*Copied\s*$/gim, '');
 
     if (this._isOpenAiDocsPage(options.pageUrl)) {
+      sanitized = this._normalizeOpenAiWrappedCardLinks(sanitized, options.pageUrl);
       sanitized = this._normalizeOpenAiExampleTaskCards(sanitized);
       sanitized = this._stripOpenAiPagerNavigation(sanitized);
       sanitized = this._normalizeOpenAiQuickstartTabSummary(sanitized);
+      sanitized = this._normalizeOpenAiCliSetupCards(sanitized, options.pageUrl);
       sanitized = this._collapseOpenAiThemeVariantPairs(sanitized);
+      sanitized = this._simplifyOpenAiUseCasesIndex(sanitized, options.pageUrl);
     }
 
     sanitized = this._dedupeConsecutiveImageParagraphs(sanitized);
 
     return sanitized.replace(/\n{3,}/g, '\n\n').trim();
+  }
+
+  /**
+   * 将 Codex Models 页里被扁平化的模型卡片重建为紧凑、适合 PDF 的 Markdown。
+   *
+   * @param {string} markdown
+   * @param {Array<{ heading: string, cards: Array<Object>, notes?: string[] }>} modelSections
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _normalizeOpenAiModelsPage(markdown, modelSections = [], pageUrl = '') {
+    if (!markdown || !/\/codex\/models\/?$/.test(pageUrl) || !Array.isArray(modelSections) || modelSections.length === 0) {
+      return markdown;
+    }
+
+    const iconScaleByTitle = {};
+    for (const section of modelSections) {
+      for (const card of section.cards || []) {
+        for (const feature of card.features || []) {
+          if (!feature?.title || !feature.iconCount) {
+            continue;
+          }
+
+          iconScaleByTitle[feature.title] = Math.max(
+            iconScaleByTitle[feature.title] || 0,
+            feature.iconCount
+          );
+        }
+      }
+    }
+
+    const wrapKnownModelNames = (text) => {
+      if (!text) return text;
+
+      return text.replace(/\b(gpt-\d+(?:\.\d+)?(?:-[a-z0-9]+)*)\b/gi, '`$1`');
+    };
+
+    const formatFeature = (feature) => {
+      if (!feature?.title) return '';
+
+      if (typeof feature.value === 'boolean') {
+        return `- ${feature.title}: ${feature.value ? 'Yes' : 'No'}`;
+      }
+
+      if (typeof feature.value === 'string' && feature.value.trim()) {
+        return `- ${feature.title}: ${feature.value.trim()}`;
+      }
+
+      if (feature.iconCount) {
+        const max = iconScaleByTitle[feature.title] || feature.iconCount;
+        return `- ${feature.title}: ${feature.iconCount}/${max}`;
+      }
+
+      return `- ${feature.title}`;
+    };
+
+    const formatCard = (card) => {
+      if (!card?.name) return '';
+
+      const parts = [`### ${card.name}`];
+
+      if (card.description) {
+        parts.push('', card.description);
+      }
+
+      if (card.command) {
+        parts.push('', '```bash', card.command, '```');
+      }
+
+      const featureLines = (card.features || []).map(formatFeature).filter(Boolean);
+      if (featureLines.length > 0) {
+        parts.push('', featureLines.join('\n'));
+      }
+
+      return parts.join('\n');
+    };
+
+    const escapeHeading = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    let normalized = markdown;
+    for (let index = 0; index < modelSections.length; index++) {
+      const section = modelSections[index];
+      if (!section?.heading || !Array.isArray(section.cards) || section.cards.length === 0) {
+        continue;
+      }
+
+      const nextHeading = modelSections[index + 1]?.heading || 'Other models';
+      const sectionBody = section.cards
+        .map(formatCard)
+        .filter(Boolean)
+        .join('\n\n');
+      const noteBody = (section.notes || [])
+        .map((note) => wrapKnownModelNames(note))
+        .filter(Boolean)
+        .join('\n\n');
+      const replacement = [sectionBody, noteBody].filter(Boolean).join('\n\n');
+
+      if (!replacement) {
+        continue;
+      }
+
+      const pattern = new RegExp(
+        `(## ${escapeHeading(section.heading)}\\n\\n)([\\s\\S]*?)(?=\\n## ${escapeHeading(nextHeading)}\\n|$)`
+      );
+
+      normalized = normalized.replace(pattern, `$1${replacement}\n\n`);
+    }
+
+    return normalized;
   }
 
   /**
@@ -539,6 +791,134 @@ export class MarkdownService {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * 修复 OpenAI 首页等页面中的“整块卡片是链接”被 Turndown 打碎后的残留 Markdown。
+   *
+   * 典型坏形态：
+   * [
+   *
+   * ### Quickstart
+   *
+   * Download and start building with Codex.
+   *
+   * Get started](https://...)
+   *
+   * 期望输出：
+   * ### Quickstart
+   *
+   * Download and start building with Codex.
+   *
+   * [Get started](https://...)
+   *
+   * @param {string} markdown
+   * @returns {string}
+   * @private
+   */
+  _normalizeOpenAiWrappedCardLinks(markdown, pageUrl = '') {
+    if (!markdown) return markdown;
+
+    let normalized = markdown;
+
+    normalized = normalized.replace(/^\s*\[\]\([^)]+\)\s*$/gm, '');
+
+    normalized = normalized.replace(
+      /\[\s*((?:!\[[^\]]*]\([^)]*\)\s*)+)\n*(#{1,6}\s+[^\n]+)\n+([\s\S]*?)(?:\n+\]\(([^)\n]+)\)|\]\(([^)\n]+)\))(?=\s*(?:\n|$|\[))/g,
+      (match, images, heading, body, lineBreakUrl, inlineUrl) => {
+        const resolvedUrl = this._resolveResourceUrl((lineBreakUrl || inlineUrl || '').trim(), pageUrl);
+        const normalizedImages = images.trim();
+        const normalizedBody = body.trim();
+        const headingMatch = heading.trim().match(/^(#{1,6})\s+(.+)$/);
+
+        if (!normalizedImages || !normalizedBody || !headingMatch) {
+          return match;
+        }
+
+        const [, hashes, headingText] = headingMatch;
+        const linkedHeading = `${hashes} [${headingText.trim()}](${resolvedUrl})`;
+
+        return [normalizedImages, '', linkedHeading, '', normalizedBody, '', ''].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /\[\s*((?:!\[[^\]]*]\([^)]*\)\s*)+)\n*([^\n#![][^)\n]*)\n+([\s\S]*?)(?:\n+\]\(([^)\n]+)\)|\]\(([^)\n]+)\))(?=\s*(?:\n|$|\[))/g,
+      (match, images, title, body, lineBreakUrl, inlineUrl) => {
+        const resolvedUrl = this._resolveResourceUrl((lineBreakUrl || inlineUrl || '').trim(), pageUrl);
+        const normalizedImages = images.trim();
+        const normalizedTitle = title.trim();
+        const normalizedBody = body.trim();
+
+        if (!normalizedImages || !normalizedTitle || !normalizedBody || !resolvedUrl) {
+          return match;
+        }
+
+        return [
+          normalizedImages,
+          '',
+          `### [${normalizedTitle}](${resolvedUrl})`,
+          '',
+          normalizedBody,
+          '',
+          '',
+        ].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /\[\s*\n+(#{1,6}\s+[^\n]+)\n+([\s\S]*?)\n+\]\(([^)\n]+)\)(?=\s*(?:\n|$|\[))/g,
+      (match, heading, body, url) => {
+        const headingMatch = heading.trim().match(/^(#{1,6})\s+(.+)$/);
+        const normalizedBody = body.trim();
+        const normalizedUrl = this._resolveResourceUrl(url.trim(), pageUrl);
+
+        if (!headingMatch || !normalizedBody || !normalizedUrl) {
+          return match;
+        }
+
+        const [, hashes, headingText] = headingMatch;
+        const linkedHeading = `${hashes} [${headingText.trim()}](${normalizedUrl})`;
+
+        return [linkedHeading, '', normalizedBody, '', ''].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /\[\s*\n+(#{1,6}\s+[^\n]+)\n+([\s\S]*?)\n+([^\]\n]+)\]\(([^)\n]+)\)(?=\s*(?:\n|$|\[))/g,
+      (match, heading, body, label, url) => {
+        const normalizedHeading = heading.trim();
+        const normalizedBody = body.trim();
+        const normalizedLabel = label.trim();
+        const normalizedUrl = this._resolveResourceUrl(url.trim(), pageUrl);
+
+        if (!normalizedHeading || !normalizedBody || !normalizedLabel || !normalizedUrl) {
+          return match;
+        }
+
+        return [
+          normalizedHeading,
+          '',
+          normalizedBody,
+          '',
+          `[${normalizedLabel}](${normalizedUrl})`,
+          '',
+          '',
+        ].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /(\[[^\]\n]+]\([^)]+\))(?=\[[^\]\n]+]\([^)]+\))/g,
+      '$1\n'
+    );
+
+    normalized = normalized.replace(
+      /^\[([^\n\]]+\[[^\]]+]\([^)]+\)[^\n]*)$/gm,
+      '$1'
+    );
+
+    return normalized;
   }
 
   /**
@@ -578,8 +958,13 @@ export class MarkdownService {
   _stripOpenAiPagerNavigation(markdown) {
     if (!markdown) return markdown;
 
-    return markdown.replace(
+    const strippedPair = markdown.replace(
       /\[\s*Previous[\s\S]*?]\([^)]+\)\s*\[\s*Next[\s\S]*?]\([^)]+\)\s*$/m,
+      ''
+    );
+
+    return strippedPair.replace(
+      /\[\s*(?:Previous|Next)\s*[\s\S]*?]\([^)]+\)\s*$/m,
       ''
     );
   }
@@ -598,6 +983,49 @@ export class MarkdownService {
       /^AppRecommendedIDE extensionCodex in your IDECLICodex in your terminalCloudCodex in your browser$/m,
       ['- App (Recommended)', '- IDE extension', '- CLI', '- Cloud'].join('\n')
     );
+  }
+
+  /**
+   * 清理 Codex CLI 首页中由步骤卡片转换出来的重复数字与冗余标签。
+   *
+   * @param {string} markdown
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _normalizeOpenAiCliSetupCards(markdown, pageUrl = '') {
+    if (!markdown || !/\/codex\/cli\/?$/.test(pageUrl)) {
+      return markdown;
+    }
+
+    return markdown
+      .replace(/^(\d+)\.\s+\1\s*$/gm, '$1.')
+      .replace(/^\s*[A-Za-z][A-Za-z\s]+ command\s*$/gm, '');
+  }
+
+  /**
+   * 精简 Codex use-cases 首页里的筛选按钮与装饰性大图，避免目录页在 PDF 中被图片撑成多页。
+   *
+   * @param {string} markdown
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _simplifyOpenAiUseCasesIndex(markdown, pageUrl = '') {
+    if (!markdown || !/\/codex\/use-cases\/?$/.test(pageUrl)) {
+      return markdown;
+    }
+
+    return markdown
+      .replace(
+        /^\[(?:[^\]]+)]\([^)]*\?search=[^)]+\)(?:\s+\[(?:[^\]]+)]\([^)]*\?search=[^)]+\))*\s*$/gm,
+        ''
+      )
+      .replace(
+        /^(?:#{1,6}\s+)?No use cases match these filters\s*\n+Try clearing a few filters or searching for a broader term\.\s*$/m,
+        ''
+      )
+      .replace(/^\s*(?:!\[[^\]]*]\([^)]+\)\s*)+\s*$/gm, '');
   }
 
   /**

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import { createHash } from 'crypto';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { mdxFromMarkdown } from 'mdast-util-mdx';
 import { mdxjs } from 'micromark-extension-mdxjs';
@@ -1381,8 +1382,55 @@ export class PandocPdfService {
       cleaned = lines.join('\n');
     }
 
+    // 4d. Normalize escaped inline-code delimiters outside fenced code blocks.
+    // Some scraped pages escape inline backticks (`\`cmd\``), which renders as
+    // odd quote-like characters instead of inline code in the final PDF.
+    {
+      const lines = cleaned.split('\n');
+      let inFence = false;
+      let fenceChar = '';
+      let fenceCount = 0;
+      for (let i = 0; i < lines.length; i++) {
+        const fenceMatch = lines[i].match(/^>?\s*(`{3,}|~{3,})/);
+        if (fenceMatch) {
+          const fc = fenceMatch[1][0];
+          const fcCount = fenceMatch[1].length;
+          if (!inFence) {
+            inFence = true;
+            fenceChar = fc;
+            fenceCount = fcCount;
+          } else if (fc === fenceChar && fcCount >= fenceCount) {
+            inFence = false;
+          }
+          continue;
+        }
+        if (inFence) continue;
+        lines[i] = lines[i]
+          .replace(/`([^`\n]*(?:\\`[^`\n]+\\`[^`\n]*)+)\\`/g, (_match, inner) => {
+            const normalizedInner = inner.replace(/\\`/g, '`').replace(/[\u201c\u201d]/g, '"');
+            return `\`\`${normalizedInner}\`\``;
+          })
+          .replace(/\\`([^`\n]+)\\`/g, '`$1`')
+          .replace(/([.?!]["“”'])\\`/g, '$1');
+      }
+      cleaned = lines.join('\n');
+    }
+
     // 5. 将图片 URL 中的 fm=webp 替换为 fm=png（LaTeX 不支持 webp 格式）
     cleaned = cleaned.replace(/fm=webp/g, 'fm=png');
+
+    // 6. 规范化 XeLaTeX 在当前字体组合下容易出现排版异常或缺字的字符。
+    // 这里仅处理已经验证会影响阅读体验的少量字符：
+    // - 弯单引号在正文中容易渲染成断裂字距（doesn’t -> doesn't）
+    // - Command 符号 ⌘ 在当前主字体下缺字
+    // - 少量 emoji / 符号会退化成缺字方框，改成可读的文本等价物
+    // - Word Joiner / 零宽字符会让 Pandoc/XeLaTeX 产生奇怪断词
+    cleaned = cleaned
+      .replace(/[\u2018\u2019]/g, "'")
+      .replace(/\u2318/g, 'Cmd')
+      .replace(/\u{1F440}/gu, ':eyes:')
+      .replace(/\u2194/g, '<->')
+      .replace(/\u200b|\u200c|\u200d|\u2060|\ufeff/g, '');
 
     return cleaned;
   }
@@ -1401,18 +1449,21 @@ export class PandocPdfService {
       ...(options || {}),
     };
     const cjkMainFont = markdownPdfConfig.cjkMainFont || 'Noto Sans CJK SC';
+    const headerPath = fileURLToPath(new URL('../templates/pandoc-code-blocks.tex', import.meta.url));
 
     const args = [
       inputPath,
       '-o',
       outputPath,
+      '--from',
+      'markdown-smart', // Keep ASCII apostrophes/quotes; avoid XeLaTeX smart-punctuation regressions
       '--pdf-engine=xelatex', // 使用 xelatex 支持中文
+      '--include-in-header',
+      headerPath,
       '--variable',
       `CJKmainfont=${cjkMainFont}`, // 主字体（使用 CI 可用的开源字体，支持通过配置覆盖）
       '--variable',
       'geometry:margin=1in', // 页边距
-      '--variable',
-      'header-includes=\\usepackage{fvextra} \\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,fontsize=\\\\small,commandchars=\\\\\\{\\}} \\usepackage{xurl}', // 启用代码换行(支持任意位置)、缩小代码字号并增强 URL 换行。不再使用 ltablex 防止表格溢出
     ];
 
     // 添加其他选项
@@ -1671,9 +1722,11 @@ export class PandocPdfService {
         // Remove frontmatter if present
         content = this._removeFrontmatter(content);
 
-        // Get article title
-        const title =
-          articleTitles[pageIndex] || this._extractTitleFromContent(content) || `Page ${pageIndex}`;
+        const title = this._selectBatchTitle(
+          content,
+          articleTitles[pageIndex],
+          `Page ${pageIndex}`
+        );
 
         // Strip leading title from content if it duplicates the injected title
         const cleanedContent = this._stripLeadingTitle(content, title);
@@ -1698,8 +1751,7 @@ export class PandocPdfService {
       let content = fs.readFileSync(filePath, 'utf8');
       content = this._removeFrontmatter(content);
 
-      const title =
-        (index && articleTitles[index]) || this._extractTitleFromContent(content) || file;
+      const title = this._selectBatchTitle(content, index && articleTitles[index], file);
       const cleanedContent = this._stripLeadingTitle(content, title);
       parts.push(`\\newpage\n\n## ${title}\n\n${cleanedContent}\n`);
 
@@ -1727,8 +1779,7 @@ export class PandocPdfService {
       const prefix = file.split('-')[0];
       const index = /^\d+$/.test(prefix) ? String(parseInt(prefix, 10)) : null;
 
-      const title =
-        (index && articleTitles[index]) || this._extractTitleFromContent(content) || file;
+      const title = this._selectBatchTitle(content, index && articleTitles[index], file);
       const cleanedContent = this._stripLeadingTitle(content, title);
 
       // Add with page break (first page doesn't need break)
@@ -1740,6 +1791,20 @@ export class PandocPdfService {
     }
 
     return parts.join('\n');
+  }
+
+  /**
+   * 为 batch PDF 选择最适合读者阅读的标题。
+   * 优先使用页面正文中的 H1/H2，其次才回退到浏览器 title/metadata。
+   *
+   * @param {string} content
+   * @param {string} preferredTitle
+   * @param {string} fallbackTitle
+   * @returns {string}
+   * @private
+   */
+  _selectBatchTitle(content, preferredTitle, fallbackTitle) {
+    return this._extractTitleFromContent(content) || preferredTitle || fallbackTitle;
   }
 
   /**

--- a/src/services/stateManager.js
+++ b/src/services/stateManager.js
@@ -224,6 +224,39 @@ export class StateManager extends EventEmitter {
   }
 
   /**
+   * 检查已处理URL对应的输出文件是否仍然存在。
+   * 如果状态已标记为已处理，但产物或映射缺失，则自动清理脏状态并返回 false。
+   *
+   * @param {string} url
+   * @returns {Promise<boolean>}
+   */
+  async hasValidProcessedOutput(url) {
+    if (!this.state.processedUrls.has(url)) {
+      return false;
+    }
+
+    const outputPath = this.state.urlToFile.get(url);
+    if (!outputPath) {
+      this.state.processedUrls.delete(url);
+      this.logger.warn('已处理URL缺少输出文件映射，按未处理恢复', { url });
+      return false;
+    }
+
+    const exists = await this.fileService.exists(outputPath);
+    if (exists) {
+      return true;
+    }
+
+    this.state.processedUrls.delete(url);
+    this.state.urlToFile.delete(url);
+    this.logger.warn('已处理URL的输出文件不存在，按未处理恢复', {
+      url,
+      outputPath,
+    });
+    return false;
+  }
+
+  /**
    * 标记URL为已处理
    */
   markProcessed(url, filePath = null) {

--- a/src/templates/pandoc-code-blocks.tex
+++ b/src/templates/pandoc-code-blocks.tex
@@ -1,0 +1,63 @@
+% Shared Pandoc PDF code-block styling.
+%
+% Goals:
+% - wrap long lines in both plain fenced blocks (`verbatim`) and syntax-highlighted blocks
+% - keep a clear block container in the PDF for readability
+% - avoid visible wrap markers that are not present in the source
+
+\usepackage{fvextra}
+\usepackage{framed}
+\definecolor{codeblockbg}{RGB}{245,247,250}
+\definecolor{codeblockborder}{RGB}{220,224,228}
+
+\fvset{
+  breaklines,
+  breakanywhere,
+  breaksymbolleft={},
+  breaksymbolright={},
+  breakindent=1em,
+  fontsize=\small
+}
+
+% Pandoc emits untyped fenced code blocks as `verbatim`, so we recustomize it
+% directly to keep long prompts/commands readable in PDFs.
+\RecustomVerbatimEnvironment{verbatim}{Verbatim}{
+  breaklines,
+  breakanywhere,
+  breaksymbolleft={},
+  breaksymbolright={},
+  breakindent=1em,
+  fontsize=\small,
+  frame=single,
+  framesep=0.6em,
+  rulecolor=\color{codeblockborder}
+}
+
+% Pandoc defines `Shaded` later in its template, so defer the redefinition
+% until the document begins. This keeps syntax-highlighted blocks in a light
+% container similar to the docs site while remaining print-friendly.
+\makeatletter
+\AtBeginDocument{
+  \@ifundefined{Shaded}{
+    \newenvironment{Shaded}{
+      \def\FrameCommand{
+        \fboxsep=0.6em
+        \colorbox{codeblockbg}
+      }
+      \MakeFramed{\advance\hsize-\width\FrameRestore}
+    }{
+      \endMakeFramed
+    }
+  }{
+    \renewenvironment{Shaded}{
+      \def\FrameCommand{
+        \fboxsep=0.6em
+        \colorbox{codeblockbg}
+      }
+      \MakeFramed{\advance\hsize-\width\FrameRestore}
+    }{
+      \endMakeFramed
+    }
+  }
+}
+\makeatother

--- a/tests/core/scraper.test.js
+++ b/tests/core/scraper.test.js
@@ -65,6 +65,7 @@ describe('Scraper', () => {
         load: vi.fn(),
         save: vi.fn(),
         isProcessed: vi.fn().mockReturnValue(false),
+        hasValidProcessedOutput: vi.fn().mockResolvedValue(true),
         markProcessed: vi.fn(),
         markFailed: vi.fn(),
         clearFailure: vi.fn(),
@@ -387,6 +388,7 @@ describe('Scraper', () => {
 
     it('should skip already processed pages', async () => {
       mockDependencies.stateManager.isProcessed.mockReturnValue(true);
+      mockDependencies.stateManager.hasValidProcessedOutput.mockResolvedValue(true);
 
       const result = await scraper.scrapePage(testUrl, testIndex);
 
@@ -396,6 +398,28 @@ describe('Scraper', () => {
       });
       expect(mockDependencies.progressTracker.skip).toHaveBeenCalledWith(testUrl);
       expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it('should re-scrape processed pages when the tracked output is missing', async () => {
+      mockDependencies.stateManager.isProcessed.mockReturnValue(true);
+      mockDependencies.stateManager.hasValidProcessedOutput.mockResolvedValue(false);
+
+      const result = await scraper.scrapePage(testUrl, testIndex);
+
+      expect(result).toEqual({
+        status: 'success',
+        title: 'Page Title',
+        outputPath: './pdfs/001-page.pdf',
+        isBatchMode: false,
+        imagesLoaded: true,
+      });
+      expect(mockDependencies.progressTracker.skip).not.toHaveBeenCalled();
+      expect(mockDependencies.pageManager.createPage).toHaveBeenCalledWith('scraper-page-0');
+      expect(mockPage.goto).toHaveBeenCalled();
+      expect(mockDependencies.logger.info).toHaveBeenCalledWith(
+        '检测到已处理状态但输出缺失，重新爬取当前URL',
+        { url: testUrl }
+      );
     });
 
     it('should handle page navigation errors', async () => {

--- a/tests/services/markdownService.test.js
+++ b/tests/services/markdownService.test.js
@@ -164,6 +164,28 @@ describe('MarkdownService', () => {
     expect(result).not.toContain('Automations');
   });
 
+  test('sanitizeMarkdown 不应误删正文里的 Next.js 链接', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      'See [Next.js setup](https://developers.openai.com/codex/setup-nextjs) for framework-specific instructions.',
+      '',
+      '[',
+      '',
+      'Next',
+      '',
+      'Automations',
+      '',
+      '](/codex/app/automations)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/app/review',
+    });
+
+    expect(result).toContain('[Next.js setup](https://developers.openai.com/codex/setup-nextjs)');
+    expect(result).not.toContain('Automations');
+  });
+
   test('sanitizeMarkdown 应该对 Quickstart 的页签摘要做兜底格式化', () => {
     const service = new MarkdownService({ logger });
     const markdown =

--- a/tests/services/markdownService.test.js
+++ b/tests/services/markdownService.test.js
@@ -201,6 +201,349 @@ describe('MarkdownService', () => {
     expect(result).toContain('plugin-creator-invoke.png');
   });
 
+  test('sanitizeMarkdown 应该修复 OpenAI 首页卡片链接被打碎后的残留 Markdown', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '### Quickstart',
+      '',
+      'Download and start building with Codex.',
+      '',
+      'Get started](https://developers.openai.com/codex/quickstart)',
+      '',
+      '[',
+      '',
+      '### Codex for Open Source',
+      '',
+      'Apply or nominate maintainers for API credits, ChatGPT Pro with Codex, and selective Codex Security access.',
+      '',
+      'Learn more](https://developers.openai.com/community/codex-for-oss)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex',
+    });
+
+    expect(result).toContain('### Quickstart');
+    expect(result).toContain('[Get started](https://developers.openai.com/codex/quickstart)');
+    expect(result).toContain('### Codex for Open Source');
+    expect(result).toContain(
+      '[Learn more](https://developers.openai.com/community/codex-for-oss)'
+    );
+    expect(result).toContain(
+      '[Get started](https://developers.openai.com/codex/quickstart)\n\n### Codex for Open Source'
+    );
+    expect(result).not.toMatch(/^\[$/m);
+  });
+
+  test('sanitizeMarkdown 应该修复带图片的 OpenAI 卡片整块链接并补全相对链接', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '![](https://developers.openai.com/codex/use-cases/gh-pr-use-case.png)',
+      '',
+      '### Review pull requests faster',
+      '',
+      'Catch regressions and potential issues before human review.',
+      '',
+      'Integrations Workflow',
+      '',
+      '](/codex/use-cases/github-code-reviews)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/use-cases',
+    });
+
+    expect(result).toContain(
+      '### [Review pull requests faster](https://developers.openai.com/codex/use-cases/github-code-reviews)'
+    );
+    expect(result).toContain('Catch regressions and potential issues before human review.');
+    expect(result).toContain('Integrations Workflow');
+    expect(result).not.toMatch(/^>\s*$/m);
+  });
+
+  test('sanitizeMarkdown 应该正确拆分同一行闭合并串接下一张图片卡片的 OpenAI 集合卡片', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '![](https://developers.openai.com/codex/use-cases/background-codex-collection1.png) ![](https://developers.openai.com/codex/use-cases/production-systems-illustration.png)',
+      '',
+      '## Production systems',
+      '',
+      'Use Codex to navigate real codebases, make controlled changes, codify repeatable work, and keep production quality high.](/codex/use-cases/collections/production-systems) [![](https://developers.openai.com/codex/use-cases/background-codex-collection2.png) ![](https://developers.openai.com/codex/use-cases/analysis-collaboration-illustration.png)',
+      '',
+      '## Productivity and collaboration',
+      '',
+      'Work with Codex to analyze data and complex source material, combine multiple apps and services, and turn insights into action.](/codex/use-cases/collections/productivity-and-collaboration)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/use-cases',
+    });
+
+    expect(result).toContain(
+      '## [Production systems](https://developers.openai.com/codex/use-cases/collections/production-systems)'
+    );
+    expect(result).toContain(
+      '## [Productivity and collaboration](https://developers.openai.com/codex/use-cases/collections/productivity-and-collaboration)'
+    );
+    expect(result).not.toContain('github-code-reviews');
+    expect(result).not.toContain('](/codex/use-cases/collections/production-systems) [![]');
+  });
+
+  test('sanitizeMarkdown 应该修复带图片和纯文本标题的 OpenAI 横幅卡片', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '![](https://developers.openai.com/images/codex/codex-banner-icon.webp)',
+      '',
+      'Use the Codex app on Windows',
+      '',
+      'Work across projects, run parallel agent threads, and review results in one place with the native Windows app.',
+      '',
+      '](/codex/app/windows)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/windows',
+    });
+
+    expect(result).toContain(
+      '### [Use the Codex app on Windows](https://developers.openai.com/codex/app/windows)'
+    );
+    expect(result).toContain(
+      'Work across projects, run parallel agent threads, and review results in one place with the native Windows app.'
+    );
+    expect(result).not.toMatch(/^\[$/m);
+  });
+
+  test('sanitizeMarkdown 应该修复无按钮文案的 OpenAI 功能卡片并移除尾部 Next 导航残留', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '### Prompt with editor context',
+      '',
+      'Use open files, selections, and `@file` references to get more relevant results with shorter prompts.',
+      '',
+      '](https://developers.openai.com/codex/ide/features#prompting-codex)[',
+      '',
+      '### Switch models',
+      '',
+      'Use the default model or switch to other models to leverage their respective strengths.',
+      '',
+      '](https://developers.openai.com/codex/ide/features#switch-between-models)',
+      '',
+      '[',
+      '',
+      'Next',
+      '',
+      'Features',
+      '',
+      '](https://developers.openai.com/codex/ide/features)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/ide',
+    });
+
+    expect(result).toContain(
+      '### [Prompt with editor context](https://developers.openai.com/codex/ide/features#prompting-codex)'
+    );
+    expect(result).toContain(
+      '### [Switch models](https://developers.openai.com/codex/ide/features#switch-between-models)'
+    );
+    expect(result).toContain(
+      'Use open files, selections, and `@file` references to get more relevant results with shorter prompts.\n\n### [Switch models](https://developers.openai.com/codex/ide/features#switch-between-models)'
+    );
+    expect(result).not.toContain('](https://developers.openai.com/codex/ide/features#prompting-codex)[');
+    expect(result).not.toContain('Next\n\nFeatures');
+  });
+
+  test('sanitizeMarkdown 应该拆开 OpenAI 文档里粘连在一起的下载链接', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[Download for macOS (Apple Silicon)](https://persistent.oaistatic.com/codex-app-prod/Codex.dmg)[Download for macOS (Intel)](https://persistent.oaistatic.com/codex-app-prod/Codex-latest-x64.dmg)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/quickstart',
+    });
+
+    expect(result).toContain(
+      '[Download for macOS (Apple Silicon)](https://persistent.oaistatic.com/codex-app-prod/Codex.dmg)\n[Download for macOS (Intel)](https://persistent.oaistatic.com/codex-app-prod/Codex-latest-x64.dmg)'
+    );
+  });
+
+  test('sanitizeMarkdown 应该清理 Codex CLI 首页步骤卡片里的重复数字和 command 标签', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '1.  1',
+      '',
+      '    ### Install',
+      '',
+      '    Install the Codex CLI with npm.',
+      '',
+      '    npm install command',
+      '',
+      '    npm i -g @openai/codex',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/cli',
+    });
+
+    expect(result).toContain('1.');
+    expect(result).not.toContain('1.  1');
+    expect(result).not.toContain('npm install command');
+  });
+
+  test('sanitizeMarkdown 应该精简 Codex Use Cases 首页里的筛选按钮和装饰性大图', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '# Codex Use Cases',
+      '',
+      '[Workflow](https://developers.openai.com/codex/use-cases?search=Workflow) [Integrations](https://developers.openai.com/codex/use-cases?search=Integrations) [Knowledge Work](https://developers.openai.com/codex/use-cases?search=Knowledge+Work)',
+      '',
+      '## Collections',
+      '',
+      '![](https://developers.openai.com/codex/use-cases/background-codex-collection1.png) ![](https://developers.openai.com/codex/use-cases/production-systems-illustration.png)',
+      '',
+      '## [Production systems](https://developers.openai.com/codex/use-cases/collections/production-systems)',
+      '',
+      'Use Codex to navigate real codebases, make controlled changes, codify repeatable work, and keep production quality high.',
+      '',
+      '## All use cases',
+      '',
+      '![](https://developers.openai.com/images/codex/codex-wallpaper-1.webp)',
+      '',
+      '### [Add iOS app intents](https://developers.openai.com/codex/use-cases/ios-app-intents)',
+      '',
+      'Use Codex to make your app’s actions and content available to Shortcuts, Siri, Spotlight...',
+      '',
+      'iOS Code',
+      '',
+      '## No use cases match these filters',
+      '',
+      'Try clearing a few filters or searching for a broader term.',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/use-cases',
+    });
+
+    expect(result).toContain('# Codex Use Cases');
+    expect(result).toContain('## Collections');
+    expect(result).toContain(
+      '## [Production systems](https://developers.openai.com/codex/use-cases/collections/production-systems)'
+    );
+    expect(result).toContain(
+      '### [Add iOS app intents](https://developers.openai.com/codex/use-cases/ios-app-intents)'
+    );
+    expect(result).toContain('iOS Code');
+    expect(result).not.toContain('?search=Workflow');
+    expect(result).not.toContain('background-codex-collection1.png');
+    expect(result).not.toContain('codex-wallpaper-1.webp');
+    expect(result).not.toContain('No use cases match these filters');
+  });
+
+  test('normalizeOpenAiModelsPage 应该把 Codex Models 卡片重建为紧凑可读的列表', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '# Codex Models',
+      '',
+      '## Recommended models',
+      '',
+      '![gpt-5.4](https://developers.openai.com/images/api/models/gpt-5.4.jpg)',
+      '',
+      'gpt-5.4',
+      '',
+      'Flagship frontier model for professional work.',
+      '',
+      'codex -m gpt-5.4',
+      '',
+      'Capability',
+      '',
+      'Speed',
+      '',
+      'Codex CLI & SDK',
+      '',
+      'Codex Cloud',
+      '',
+      'For most tasks in Codex, start with `gpt-5.4`.',
+      '',
+      '## Alternative models',
+      '',
+      'gpt-5.2',
+      '',
+      'Previous general-purpose model.',
+      '',
+      'codex -m gpt-5.2',
+      '',
+      'Show details',
+      '',
+      '## Other models',
+      '',
+      'When you sign in with ChatGPT, Codex works best with the models listed above.',
+    ].join('\n');
+
+    const result = service._normalizeOpenAiModelsPage(
+      markdown,
+      [
+        {
+          heading: 'Recommended models',
+          cards: [
+            {
+              name: 'gpt-5.4',
+              description: 'Flagship frontier model for professional work.',
+              command: 'codex -m gpt-5.4',
+              features: [
+                { title: 'Capability', iconCount: 5, value: '' },
+                { title: 'Speed', iconCount: 3, value: '' },
+                { title: 'Codex CLI & SDK', value: true, iconCount: 0 },
+                { title: 'Codex Cloud', value: false, iconCount: 0 },
+              ],
+            },
+          ],
+          notes: ['For most tasks in Codex, start with gpt-5.4.'],
+        },
+        {
+          heading: 'Alternative models',
+          cards: [
+            {
+              name: 'gpt-5.2',
+              description: 'Previous general-purpose model.',
+              command: 'codex -m gpt-5.2',
+              features: [
+                { title: 'Capability', iconCount: 4, value: '' },
+                { title: 'Speed', iconCount: 3, value: '' },
+                { title: 'Codex CLI & SDK', value: true, iconCount: 0 },
+              ],
+            },
+          ],
+          notes: [],
+        },
+      ],
+      'https://developers.openai.com/codex/models'
+    );
+
+    expect(result).toContain('### gpt-5.4');
+    expect(result).toContain('```bash\ncodex -m gpt-5.4\n```');
+    expect(result).toContain('- Capability: 5/5');
+    expect(result).toContain('- Speed: 3/3');
+    expect(result).toContain('- Codex CLI & SDK: Yes');
+    expect(result).toContain('- Codex Cloud: No');
+    expect(result).toContain('For most tasks in Codex, start with `gpt-5.4`.');
+    expect(result).toContain('### gpt-5.2');
+    expect(result).not.toContain('![gpt-5.4]');
+    expect(result).not.toContain('Show details');
+  });
+
   test('代码块应保留语言标识', () => {
     const service = new MarkdownService({ logger });
     const html = '<pre><code class="language-js">const x = 1;</code></pre>';

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -70,7 +70,10 @@ describe('PandocPdfService', () => {
       expect(args).toContain('input.md');
       expect(args).toContain('-o');
       expect(args).toContain('output.pdf');
+      expect(args).toContain('--from');
+      expect(args).toContain('markdown-smart');
       expect(args).toContain('--pdf-engine=xelatex');
+      expect(args).toContain('--include-in-header');
     });
 
     it('should include format option', () => {
@@ -124,6 +127,15 @@ describe('PandocPdfService', () => {
 
       expect(args).toContain('CJKmainfont=Noto Sans CJK SC');
       expect(args).not.toContain('CJKmainfont=Arial Unicode MS');
+    });
+
+    it('should include the shared code-block header file instead of inline latex overrides', () => {
+      const args = service._buildPandocArgs('input.md', 'output.pdf', {});
+      const includeIndex = args.indexOf('--include-in-header');
+
+      expect(includeIndex).toBeGreaterThanOrEqual(0);
+      expect(args[includeIndex + 1]).toMatch(/pandoc-code-blocks\.tex$/);
+      expect(args.join(' ')).not.toContain('header-includes=');
     });
 
     it('should allow overriding the CJK main font from config', () => {
@@ -432,6 +444,44 @@ describe('PandocPdfService', () => {
       expect(result).toBe('<img src="https://developers.openai.com/images/app.webp" alt="App screenshot">');
     });
 
+    it('should normalize typography that renders poorly in XeLaTeX output', () => {
+      const input = "It doesn’t work⁠. Press ⌘-/ if it isn’t visible.";
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe("It doesn't work. Press Cmd-/ if it isn't visible.");
+    });
+
+    it('should replace unsupported emoji glyphs with readable text fallbacks', () => {
+      const input = 'Wait for Codex to react (👀) and post a review.';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe('Wait for Codex to react (:eyes:) and post a review.');
+    });
+
+    it('should replace unsupported arrow glyphs with ASCII fallbacks', () => {
+      const input = 'Move work between local ↔ cloud.';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe('Move work between local <-> cloud.');
+    });
+
+    it('should normalize escaped inline-code delimiters outside fenced blocks', () => {
+      const input = 'Use \\`codex exec\\` to run Codex in scripts and CI.';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe('Use `codex exec` to run Codex in scripts and CI.');
+    });
+
+    it('should remove stray escaped backticks after quoted inline-code examples', () => {
+      const input =
+        'When forbidden, suggest an alternative (for example, `"Use \\`rg\\` instead of \\`grep\\`.”\\`).';
+      const result = service._cleanMarkdownContent(input);
+
+      expect(result).toBe(
+        'When forbidden, suggest an alternative (for example, ``"Use `rg` instead of `grep`."``).'
+      );
+    });
+
     it('should preserve export/import lines inside fenced code blocks', () => {
       // Python example containing `import`, and shell `export VAR=...` must
       // survive because they are inside fenced code blocks.
@@ -634,6 +684,22 @@ describe('PandocPdfService', () => {
       await expect(service._runPandoc(inputPath, outputPath, {})).rejects.toThrow('PDF 文件未生成');
 
       spawnSpy.mockReset();
+    });
+  });
+
+  describe('_selectBatchTitle', () => {
+    it('should prefer the page heading over browser-title metadata for injected batch headings', () => {
+      const content = [
+        '- [General](#general)',
+        '',
+        '# Codex app settings',
+        '',
+        'Body content.',
+      ].join('\n');
+
+      expect(service._selectBatchTitle(content, 'Settings – Codex app', 'fallback.md')).toBe(
+        'Codex app settings'
+      );
     });
   });
 });

--- a/tests/services/stateManager.test.js
+++ b/tests/services/stateManager.test.js
@@ -15,6 +15,7 @@ describe('StateManager', () => {
     mockFileService = {
       readJson: vi.fn(),
       writeJson: vi.fn(),
+      exists: vi.fn(),
     };
 
     mockPathService = {
@@ -300,6 +301,46 @@ describe('StateManager', () => {
 
       expect(stateManager.isProcessed('http://example.com')).toBe(true);
       expect(stateManager.isProcessed('http://other.com')).toBe(false);
+    });
+
+    test('hasValidProcessedOutput应该在输出文件存在时返回true', async () => {
+      stateManager.state.processedUrls.add('http://example.com');
+      stateManager.state.urlToFile.set('http://example.com', '/path/to/file.pdf');
+      mockFileService.exists.mockResolvedValue(true);
+
+      await expect(stateManager.hasValidProcessedOutput('http://example.com')).resolves.toBe(true);
+      expect(mockFileService.exists).toHaveBeenCalledWith('/path/to/file.pdf');
+    });
+
+    test('hasValidProcessedOutput应该在缺少输出映射时清理脏状态', async () => {
+      stateManager.state.processedUrls.add('http://example.com');
+
+      await expect(stateManager.hasValidProcessedOutput('http://example.com')).resolves.toBe(
+        false
+      );
+      expect(stateManager.state.processedUrls.has('http://example.com')).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith('已处理URL缺少输出文件映射，按未处理恢复', {
+        url: 'http://example.com',
+      });
+    });
+
+    test('hasValidProcessedOutput应该在输出文件缺失时清理脏状态', async () => {
+      stateManager.state.processedUrls.add('http://example.com');
+      stateManager.state.urlToFile.set('http://example.com', '/path/to/file.pdf');
+      mockFileService.exists.mockResolvedValue(false);
+
+      await expect(stateManager.hasValidProcessedOutput('http://example.com')).resolves.toBe(
+        false
+      );
+      expect(stateManager.state.processedUrls.has('http://example.com')).toBe(false);
+      expect(stateManager.state.urlToFile.has('http://example.com')).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        '已处理URL的输出文件不存在，按未处理恢复',
+        {
+          url: 'http://example.com',
+          outputPath: '/path/to/file.pdf',
+        }
+      );
     });
 
     test('markProcessed应该标记URL为已处理', () => {


### PR DESCRIPTION
## Summary
- improve OpenAI docs markdown normalization for broken card-like content and the `codex/models` page by reconstructing model cards into compact, readable markdown
- harden Pandoc PDF output for code readability, including long-line wrapping, typography normalization, and inline code cleanup
- fix stale processed-state handling so missing outputs are re-scraped instead of being skipped
- add regression coverage for scraper state handling, markdown normalization, and Pandoc rendering cleanup

## Validation
- make test
- make lint
- manually re-checked the regenerated `codex/models` page markdown and single-page PDF rendering
