### PR TITLE
fix: harden OpenAI docs PDF rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,9 +389,31 @@ node scripts/use-kindle-config.js current
   - Indentation in Markdown (Pandoc treats indented blocks inside HTML as code).
 - **Fixes**:
   - **Overflow**: `src/services/pandocPdfService.js` uses `xurl` and disables `breakanywhere` inside critical tags if needed.
+  - **Plain fenced code blocks**: Pandoc may emit unlabeled fenced blocks as LaTeX `verbatim`, not `Highlighting`. If long code still overflows after tuning `Highlighting`, also recustomize lowercase `verbatim` in the injected header.
   - **Tables**: Ensure empty lines before/after tables.
   - **Indentation**: Remove indentation for `<table>` or custom components inside HTML wrappers to prevent "code block" rendering.
   - **Ltablex**: Do NOT use `ltablex` if it causes column overflow; we use standard tabular environments or calibrated widths.
+  - **Pandoc header injection**: Prefer `--include-in-header` with a temporary `.tex` file. Do **not** stuff raw LaTeX commands into `header-includes=...`; Pandoc may escape them into `\\usepackage`, which breaks XeLaTeX.
+  - **Remote image safety**: Do **not** decide PDF-safe image handling from URL/query params alone. Detect the downloaded bytes (or at least the actual response format) before deciding whether to keep the asset or convert it to PNG.
+  - **Figure blocks**: If scraped Markdown contains `![](image.png)Text...` on one line, split it into an image block plus a following paragraph before Pandoc. Otherwise the PDF may render badly even when generation succeeds.
+
+### Structured Content Extraction (Critical)
+- **Problem**: Pages with real UI structure (`<table>`, tablists/panels, footer pager, screenshot pairs) look fine on the website but become truncated, flattened, or visually chaotic in Markdown/PDF.
+- **Root Cause**:
+  - HTML structure was flattened too early, then "fixed" later with broad Markdown regexes.
+  - Site-specific cleanup leaked into global cleanup rules.
+- **Preferred Fix Order**:
+  1. **Inspect generated Markdown first**. If `pdfs/markdown/*.md` is already wrong, do **not** debug Pandoc first.
+  2. Prefer **DOM-structured transforms before Turndown**:
+     - remove footer pager by DOM shape, not text guesswork;
+     - preserve `<table>` as real Markdown tables;
+     - convert tablists/panels into headings or lists before flattening.
+  3. If post-Markdown cleanup is still needed, prefer **AST-based parsing** over regex.
+  4. Use regex only as a **narrow fallback**, anchored to a specific malformed pattern.
+- **Guardrails**:
+  - Do **not** use global `Copy Page` / `Copied` cleanup for every site; scope it to the target site.
+  - Do **not** remove content based on tokens like `[` / `]` alone; keyboard shortcuts and inline code often use them legitimately.
+  - When fixing one broken page, scan sibling patterns (`commands`, `models`, `quickstart`, `use-cases`) for the same structural smell before stopping.
 
 ### Visual Glitches
 - **Problem**: Floating headers/footers appear in PDF.

--- a/src/services/markdownService.js
+++ b/src/services/markdownService.js
@@ -1,4 +1,5 @@
 // src/services/markdownService.js
+import { fromMarkdown } from 'mdast-util-from-markdown';
 import TurndownService from 'turndown';
 
 /**
@@ -58,6 +59,23 @@ export class MarkdownService {
       replacement: (content) => {
         if (!content) return '';
         return `~~${content}~~`;
+      },
+    });
+
+    // 将 <kbd> 统一为行内代码，便于在 PDF 中保持快捷键的视觉边界。
+    this.turndown.addRule('keyboardKey', {
+      filter: ['kbd'],
+      replacement: (content) => this._wrapInlineCode(content),
+    });
+
+    // Turndown 默认不会把 HTML table 转成可读的 Markdown 表格。
+    // 对 OpenAI/Codex 这类大量使用 reference tables 的页面，保留表格结构
+    // 比事后对顺序文本做猜测性修补更可靠。
+    this.turndown.addRule('markdownTable', {
+      filter: ['table'],
+      replacement: (_content, node) => {
+        const markdownTable = this._convertTableToMarkdown(node);
+        return markdownTable ? `\n\n${markdownTable}\n\n` : '\n\n';
       },
     });
 
@@ -199,6 +217,145 @@ export class MarkdownService {
   }
 
   /**
+   * 将文本包裹为行内代码，自动处理内容中的反引号。
+   *
+   * @param {string} content
+   * @returns {string}
+   * @private
+   */
+  _wrapInlineCode(content) {
+    const normalized = String(content || '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    if (!normalized) {
+      return '';
+    }
+
+    const backtickRuns = normalized.match(/`+/g) || [];
+    const longestBacktickRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0);
+    const fence = '`'.repeat(longestBacktickRun + 1);
+    const needsPadding = normalized.startsWith('`') || normalized.endsWith('`');
+
+    return needsPadding ? `${fence} ${normalized} ${fence}` : `${fence}${normalized}${fence}`;
+  }
+
+  /**
+   * 将 HTML table 结构化转换为 Markdown 表格，避免丢失列关系。
+   *
+   * @param {Element} tableNode
+   * @returns {string}
+   * @private
+   */
+  _convertTableToMarkdown(tableNode) {
+    const rowNodes = Array.from(tableNode.querySelectorAll('tr')).filter((row) =>
+      Array.from(row.children).some((cell) => /^(TH|TD)$/.test(cell.nodeName))
+    );
+
+    if (rowNodes.length === 0) {
+      return '';
+    }
+
+    const rows = rowNodes.map((row) =>
+      Array.from(row.children)
+        .filter((cell) => /^(TH|TD)$/.test(cell.nodeName))
+        .map((cell) => this._serializeTableCell(cell))
+    );
+
+    const columnCount = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    if (columnCount === 0) {
+      return '';
+    }
+
+    const normalizedRows = rows.map((row) =>
+      Array.from({ length: columnCount }, (_, index) => row[index] ?? '')
+    );
+
+    const headerRow = normalizedRows[0];
+    const bodyRows = normalizedRows.slice(1);
+    const renderRow = (cells) =>
+      `| ${cells.map((cell) => (cell && cell.trim() ? cell : ' ')).join(' | ')} |`;
+
+    return [
+      renderRow(headerRow),
+      `| ${Array.from({ length: columnCount }, () => '---').join(' | ')} |`,
+      ...bodyRows.map(renderRow),
+    ].join('\n');
+  }
+
+  /**
+   * 将表格单元格序列化为 Markdown 友好的行内内容。
+   *
+   * @param {Element} cellNode
+   * @returns {string}
+   * @private
+   */
+  _serializeTableCell(cellNode) {
+    const markdown = this._serializeInlineNode(cellNode)
+      .replace(/\s*\n\s*/g, ' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+
+    return markdown.replace(/\|/g, '\\|');
+  }
+
+  /**
+   * 递归提取节点中的行内 Markdown。
+   *
+   * @param {Node} node
+   * @returns {string}
+   * @private
+   */
+  _serializeInlineNode(node) {
+    if (!node) {
+      return '';
+    }
+
+    if (node.nodeType === 3) {
+      return node.textContent || '';
+    }
+
+    if (node.nodeType !== 1) {
+      return '';
+    }
+
+    const tagName = node.nodeName.toUpperCase();
+    const childrenContent = Array.from(node.childNodes)
+      .map((child) => this._serializeInlineNode(child))
+      .join('');
+
+    switch (tagName) {
+      case 'BR':
+        return '<br>';
+      case 'CODE':
+      case 'KBD':
+        return this._wrapInlineCode(node.textContent || '');
+      case 'STRONG':
+      case 'B': {
+        const content = childrenContent.trim();
+        return content ? `**${content}**` : '';
+      }
+      case 'EM':
+      case 'I': {
+        const content = childrenContent.trim();
+        return content ? `*${content}*` : '';
+      }
+      case 'A': {
+        const content = childrenContent.trim() || (node.textContent || '').trim();
+        const href = node.getAttribute('href');
+        return href ? `[${content}](${href})` : content;
+      }
+      case 'IMG': {
+        const alt = node.getAttribute('alt') || '';
+        const src = node.getAttribute('src') || '';
+        return src ? `![${alt}](${src})` : alt;
+      }
+      default:
+        return childrenContent;
+    }
+  }
+
+  /**
    * 规范化图像与图注：
    * - 如果某行是斜体（例如 _Figure 1: ..._ 或 *Figure 1: ...*），
    * - 且其前一行（忽略空行）是 Markdown 图片行，并且两者文本几乎相同，
@@ -273,6 +430,68 @@ export class MarkdownService {
   }
 
   /**
+   * 将“图片后直接粘正文”的行拆分为独立图片块和正文段落，避免 Pandoc
+   * 把块级插图挤成同一行，影响阅读和 figure 渲染。
+   *
+   * @param {string} markdown
+   * @returns {string}
+   * @private
+   */
+  _normalizeStandaloneImageBlocks(markdown) {
+    if (!markdown || typeof markdown !== 'string') {
+      return markdown;
+    }
+
+    const lines = markdown.split('\n');
+    const result = [];
+    let inFence = false;
+    let fenceChar = '';
+    let fenceCount = 0;
+
+    for (const line of lines) {
+      const fenceMatch = line.match(/^(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        const currentFenceChar = fenceMatch[1][0];
+        const currentFenceCount = fenceMatch[1].length;
+
+        if (!inFence) {
+          inFence = true;
+          fenceChar = currentFenceChar;
+          fenceCount = currentFenceCount;
+        } else if (currentFenceChar === fenceChar && currentFenceCount >= fenceCount) {
+          inFence = false;
+        }
+
+        result.push(line);
+        continue;
+      }
+
+      if (inFence) {
+        result.push(line);
+        continue;
+      }
+
+      const markdownImageMatch = line.match(
+        /^(!\[[^\]]*]\([^)]+\)(?:\s*\{[^}]*\})?)(?=\S)(.+)$/
+      );
+      if (markdownImageMatch) {
+        result.push(markdownImageMatch[1], '', markdownImageMatch[2]);
+        continue;
+      }
+
+      const htmlImageMatch = line.match(/^(<img\b[^>]*>)(?=\S)(.+)$/i);
+      if (htmlImageMatch) {
+        result.push(htmlImageMatch[1], '', htmlImageMatch[2]);
+        continue;
+      }
+
+      result.push(line);
+    }
+
+    return result.join('\n');
+  }
+
+  /**
    * 将 HTML 字符串转换为 Markdown
    * @param {string} html
    * @returns {string}
@@ -285,7 +504,8 @@ export class MarkdownService {
     try {
       const rawMarkdown = this.turndown.turndown(html);
       const normalizedMarkdown = this.normalizeResourceUrls(rawMarkdown, options.pageUrl);
-      const dedupedMarkdown = this._normalizeFigureCaptions(normalizedMarkdown);
+      const normalizedFigureBlocks = this._normalizeStandaloneImageBlocks(normalizedMarkdown);
+      const dedupedMarkdown = this._normalizeFigureCaptions(normalizedFigureBlocks);
       const markdown = this.sanitizeMarkdown(dedupedMarkdown, options);
       this.logger?.debug?.('HTML 转 Markdown 完成', {
         length: markdown.length,
@@ -307,10 +527,10 @@ export class MarkdownService {
    */
   async extractAndConvertPage(page, selector) {
     const pageUrl = typeof page.url === 'function' ? page.url() : undefined;
-    const { html, svgCount } = await page.evaluate((contentSelector, currentPageUrl) => {
+    const { html, svgCount, openAiModelSections = [] } = await page.evaluate((contentSelector, currentPageUrl) => {
       const container = document.querySelector(contentSelector);
       if (!container) {
-        return { html: '', svgCount: 0 };
+        return { html: '', svgCount: 0, openAiModelSections: [] };
       }
 
       const clone = container.cloneNode(true);
@@ -335,7 +555,141 @@ export class MarkdownService {
         return normalizeWhitespace(textClone.textContent || '');
       };
 
+      let openAiModelSections = [];
+
       if (isOpenAiDocsPage) {
+        const decodeAstroValue = (value) => {
+          if (Array.isArray(value) && value.length === 2 && typeof value[0] === 'number') {
+            const [type, payload] = value;
+
+            if (type === 1 && Array.isArray(payload)) {
+              return payload.map(decodeAstroValue);
+            }
+
+            return decodeAstroValue(payload);
+          }
+
+          if (Array.isArray(value)) {
+            return value.map(decodeAstroValue);
+          }
+
+          if (value && typeof value === 'object') {
+            return Object.fromEntries(
+              Object.entries(value).map(([key, nestedValue]) => [key, decodeAstroValue(nestedValue)])
+            );
+          }
+
+          return value;
+        };
+
+        const parseModelCard = (island) => {
+          if (!island) return null;
+
+          let props = {};
+          try {
+            props = decodeAstroValue(JSON.parse(island.getAttribute('props') || '{}'));
+          } catch {
+            props = {};
+          }
+
+          const name = normalizeWhitespace(
+            props.name
+              || island.querySelector('img')?.getAttribute('alt')
+              || island.querySelector('.heading-md, .heading-sm, h3, h4')?.textContent
+              || ''
+          );
+          const description = normalizeWhitespace(
+            props.description || island.querySelector('p')?.textContent || ''
+          );
+          const command = normalizeWhitespace(
+            island.querySelector('.font-mono')?.textContent || (name ? `codex -m ${name}` : '')
+          );
+          const features = Array.isArray(props.data?.features)
+            ? props.data.features
+              .map((feature) => {
+                const title = normalizeWhitespace(feature?.title || '');
+                if (!title) return null;
+
+                return {
+                  title,
+                  value: typeof feature?.value === 'boolean' ? feature.value : normalizeWhitespace(feature?.value || ''),
+                  iconCount: Array.isArray(feature?.icons) ? feature.icons.length : 0,
+                };
+              })
+              .filter(Boolean)
+            : [];
+
+          if (!name && !description && !command && features.length === 0) {
+            return null;
+          }
+
+          return {
+            name,
+            description,
+            command,
+            features,
+          };
+        };
+
+        const collectModelSections = () => {
+          if (!/\/codex\/models\/?$/.test(currentPageUrl || '')) {
+            return [];
+          }
+
+          const sections = [];
+          const sectionHeadings = Array.from(clone.querySelectorAll('h2'));
+
+          sectionHeadings.forEach((heading) => {
+            const headingText = normalizeWhitespace(heading.textContent || '');
+            if (!['Recommended models', 'Alternative models'].includes(headingText)) {
+              return;
+            }
+
+            let grid = heading.nextElementSibling;
+            while (grid && !grid.querySelector?.('astro-island[component-url*="ModelDetails"]')) {
+              if (/^H2$/i.test(grid.tagName)) {
+                grid = null;
+                break;
+              }
+              grid = grid.nextElementSibling;
+            }
+
+            if (!grid) {
+              return;
+            }
+
+            const cards = Array.from(
+              grid.querySelectorAll('astro-island[component-url*="ModelDetails"]')
+            )
+              .map(parseModelCard)
+              .filter(Boolean);
+
+            if (cards.length === 0) {
+              return;
+            }
+
+            const notes = [];
+            let sibling = grid.nextElementSibling;
+            while (sibling && !/^H2$/i.test(sibling.tagName)) {
+              const text = getVisibleText(sibling);
+              if (text && !sibling.querySelector?.('astro-island[component-url*="ModelDetails"]')) {
+                notes.push(text);
+              }
+              sibling = sibling.nextElementSibling;
+            }
+
+            sections.push({
+              heading: headingText,
+              cards,
+              notes,
+            });
+          });
+
+          return sections;
+        };
+
+        openAiModelSections = collectModelSections();
+
         clone
           .querySelectorAll(
             'script, noscript, style, template, [data-page-copy-action], .page-copy-action, [data-anchor-id], [data-codex-screenshot-overlay]'
@@ -343,8 +697,14 @@ export class MarkdownService {
           .forEach((node) => node.remove());
 
         clone.querySelectorAll('nav').forEach((nav) => {
-          const text = normalizeWhitespace(nav.textContent || '');
-          if (/\bPrevious\b/.test(text) && /\bNext\b/.test(text)) {
+          const pagerLabels = Array.from(nav.querySelectorAll('a'))
+            .map((link) => normalizeWhitespace(link.textContent || '').toLowerCase())
+            .filter(Boolean);
+
+          const isPagerNav = pagerLabels.some((label) => label.startsWith('previous')) ||
+            pagerLabels.some((label) => label.startsWith('next'));
+
+          if (isPagerNav) {
             nav.remove();
           }
         });
@@ -361,10 +721,30 @@ export class MarkdownService {
           return label;
         };
 
-        clone.querySelectorAll('[role="tablist"]').forEach((tabList) => tabList.remove());
-
         const tabPanels = Array.from(clone.querySelectorAll('[data-panel][role="region"], [role="tabpanel"]'));
-        if (tabPanels.length > 1) {
+        const tabLists = Array.from(clone.querySelectorAll('[role="tablist"]'));
+
+        tabLists.forEach((tabList) => {
+          if (tabPanels.length === 0) {
+            const labels = Array.from(tabList.querySelectorAll('[role="tab"], button'))
+              .map((button) => normalizePanelLabel(getVisibleText(button)))
+              .filter(Boolean);
+
+            if (labels.length > 1 && tabList.parentNode) {
+              const list = document.createElement('ul');
+              labels.forEach((label) => {
+                const item = document.createElement('li');
+                item.textContent = label;
+                list.appendChild(item);
+              });
+              tabList.parentNode.insertBefore(list, tabList);
+            }
+          }
+
+          tabList.remove();
+        });
+
+        if (tabPanels.length > 0) {
           tabPanels.forEach((panel) => {
             panel.removeAttribute('hidden');
             panel.setAttribute('aria-hidden', 'false');
@@ -479,18 +859,24 @@ export class MarkdownService {
       return {
         html: clone.innerHTML,
         svgCount: svgs.length,
+        openAiModelSections,
       };
     }, selector, pageUrl);
 
     this.logger?.debug?.('从页面提取 HTML 完成', {
       hasContent: !!html,
       svgCount,
+      openAiModelSections: openAiModelSections.length,
     });
 
-    return this.convertHtmlToMarkdown(html, {
+    let markdown = this.convertHtmlToMarkdown(html, {
       debugMeta: { svgCount },
       pageUrl,
     });
+
+    markdown = this._normalizeOpenAiModelsPage(markdown, openAiModelSections, pageUrl);
+
+    return markdown;
   }
 
   /**
@@ -507,19 +893,130 @@ export class MarkdownService {
 
     let sanitized = markdown;
 
-    sanitized = sanitized.replace(/^\s*Copy Page\s*$/gim, '');
-    sanitized = sanitized.replace(/^\s*Copied\s*$/gim, '');
-
     if (this._isOpenAiDocsPage(options.pageUrl)) {
+      sanitized = sanitized.replace(/^\s*Copy Page\s*$/gim, '');
+      sanitized = sanitized.replace(/^\s*Copied\s*$/gim, '');
+      sanitized = this._normalizeOpenAiWrappedCardLinks(sanitized, options.pageUrl);
       sanitized = this._normalizeOpenAiExampleTaskCards(sanitized);
       sanitized = this._stripOpenAiPagerNavigation(sanitized);
       sanitized = this._normalizeOpenAiQuickstartTabSummary(sanitized);
+      sanitized = this._normalizeOpenAiCliSetupCards(sanitized, options.pageUrl);
       sanitized = this._collapseOpenAiThemeVariantPairs(sanitized);
+      sanitized = this._simplifyOpenAiUseCasesIndex(sanitized, options.pageUrl);
     }
 
     sanitized = this._dedupeConsecutiveImageParagraphs(sanitized);
 
     return sanitized.replace(/\n{3,}/g, '\n\n').trim();
+  }
+
+  /**
+   * 将 Codex Models 页里被扁平化的模型卡片重建为紧凑、适合 PDF 的 Markdown。
+   *
+   * @param {string} markdown
+   * @param {Array<{ heading: string, cards: Array<Object>, notes?: string[] }>} modelSections
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _normalizeOpenAiModelsPage(markdown, modelSections = [], pageUrl = '') {
+    if (!markdown || !/\/codex\/models\/?$/.test(pageUrl) || !Array.isArray(modelSections) || modelSections.length === 0) {
+      return markdown;
+    }
+
+    const iconScaleByTitle = {};
+    for (const section of modelSections) {
+      for (const card of section.cards || []) {
+        for (const feature of card.features || []) {
+          if (!feature?.title || !feature.iconCount) {
+            continue;
+          }
+
+          iconScaleByTitle[feature.title] = Math.max(
+            iconScaleByTitle[feature.title] || 0,
+            feature.iconCount
+          );
+        }
+      }
+    }
+
+    const wrapKnownModelNames = (text) => {
+      if (!text) return text;
+      return text.replace(/\b(gpt-\d+(?:\.\d+)?(?:-[a-z0-9]+)*)\b/gi, '`$1`');
+    };
+
+    const formatFeature = (feature) => {
+      if (!feature?.title) return '';
+
+      if (typeof feature.value === 'boolean') {
+        return `- ${feature.title}: ${feature.value ? 'Yes' : 'No'}`;
+      }
+
+      if (typeof feature.value === 'string' && feature.value.trim()) {
+        return `- ${feature.title}: ${feature.value.trim()}`;
+      }
+
+      if (feature.iconCount) {
+        const max = iconScaleByTitle[feature.title] || feature.iconCount;
+        return `- ${feature.title}: ${feature.iconCount}/${max}`;
+      }
+
+      return `- ${feature.title}`;
+    };
+
+    const formatCard = (card) => {
+      if (!card?.name) return '';
+
+      const parts = [`### ${card.name}`];
+
+      if (card.description) {
+        parts.push('', card.description);
+      }
+
+      if (card.command) {
+        parts.push('', '```bash', card.command, '```');
+      }
+
+      const featureLines = (card.features || []).map(formatFeature).filter(Boolean);
+      if (featureLines.length > 0) {
+        parts.push('', featureLines.join('\n'));
+      }
+
+      return parts.join('\n');
+    };
+
+    const escapeHeading = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    let normalized = markdown;
+    for (let index = 0; index < modelSections.length; index += 1) {
+      const section = modelSections[index];
+      if (!section?.heading || !Array.isArray(section.cards) || section.cards.length === 0) {
+        continue;
+      }
+
+      const nextHeading = modelSections[index + 1]?.heading || 'Other models';
+      const sectionBody = section.cards
+        .map(formatCard)
+        .filter(Boolean)
+        .join('\n\n');
+      const noteBody = (section.notes || [])
+        .map((note) => wrapKnownModelNames(note))
+        .filter(Boolean)
+        .join('\n\n');
+      const replacement = [sectionBody, noteBody].filter(Boolean).join('\n\n');
+
+      if (!replacement) {
+        continue;
+      }
+
+      const pattern = new RegExp(
+        `(## ${escapeHeading(section.heading)}\\n\\n)([\\s\\S]*?)(?=\\n## ${escapeHeading(nextHeading)}\\n|$)`
+      );
+
+      normalized = normalized.replace(pattern, `$1${replacement}\n\n`);
+    }
+
+    return normalized;
   }
 
   /**
@@ -539,6 +1036,116 @@ export class MarkdownService {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * 修复 OpenAI 页面中“整块卡片是链接”被 Turndown 打碎后的 Markdown。
+   *
+   * @param {string} markdown
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _normalizeOpenAiWrappedCardLinks(markdown, pageUrl = '') {
+    if (!markdown) return markdown;
+
+    let normalized = markdown;
+
+    normalized = normalized.replace(/^\s*\[\]\([^)]+\)\s*$/gm, '');
+
+    normalized = normalized.replace(
+      /\[\s*((?:!\[[^\]]*]\([^)]*\)\s*)+)\n*(#{1,6}\s+[^\n]+)\n+([\s\S]*?)(?:\n+\]\(([^)\n]+)\)|\]\(([^)\n]+)\))(?=\s*(?:\n|$|\[))/g,
+      (match, images, heading, body, lineBreakUrl, inlineUrl) => {
+        const resolvedUrl = this._resolveResourceUrl((lineBreakUrl || inlineUrl || '').trim(), pageUrl);
+        const normalizedImages = images.trim();
+        const normalizedBody = body.trim();
+        const headingMatch = heading.trim().match(/^(#{1,6})\s+(.+)$/);
+
+        if (!normalizedImages || !normalizedBody || !headingMatch || !resolvedUrl) {
+          return match;
+        }
+
+        const [, hashes, headingText] = headingMatch;
+        const linkedHeading = `${hashes} [${headingText.trim()}](${resolvedUrl})`;
+
+        return [normalizedImages, '', linkedHeading, '', normalizedBody, '', ''].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /\[\s*((?:!\[[^\]]*]\([^)]*\)\s*)+)\n*([^\n#![][^)\n]*)\n+([\s\S]*?)(?:\n+\]\(([^)\n]+)\)|\]\(([^)\n]+)\))(?=\s*(?:\n|$|\[))/g,
+      (match, images, title, body, lineBreakUrl, inlineUrl) => {
+        const resolvedUrl = this._resolveResourceUrl((lineBreakUrl || inlineUrl || '').trim(), pageUrl);
+        const normalizedImages = images.trim();
+        const normalizedTitle = title.trim();
+        const normalizedBody = body.trim();
+
+        if (!normalizedImages || !normalizedTitle || !normalizedBody || !resolvedUrl) {
+          return match;
+        }
+
+        return [
+          normalizedImages,
+          '',
+          `### [${normalizedTitle}](${resolvedUrl})`,
+          '',
+          normalizedBody,
+          '',
+          '',
+        ].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /\[\s*\n+(#{1,6}\s+[^\n]+)\n+([\s\S]*?)\n+\]\(([^)\n]+)\)(?=\s*(?:\n|$|\[))/g,
+      (match, heading, body, url) => {
+        const headingMatch = heading.trim().match(/^(#{1,6})\s+(.+)$/);
+        const normalizedBody = body.trim();
+        const normalizedUrl = this._resolveResourceUrl(url.trim(), pageUrl);
+
+        if (!headingMatch || !normalizedBody || !normalizedUrl) {
+          return match;
+        }
+
+        const [, hashes, headingText] = headingMatch;
+        const linkedHeading = `${hashes} [${headingText.trim()}](${normalizedUrl})`;
+
+        return [linkedHeading, '', normalizedBody, '', ''].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /\[\s*\n+(#{1,6}\s+[^\n]+)\n+([\s\S]*?)\n+([^\]\n]+)\]\(([^)\n]+)\)(?=\s*(?:\n|$|\[))/g,
+      (match, heading, body, label, url) => {
+        const normalizedHeading = heading.trim();
+        const normalizedBody = body.trim();
+        const normalizedLabel = label.trim();
+        const normalizedUrl = this._resolveResourceUrl(url.trim(), pageUrl);
+
+        if (!normalizedHeading || !normalizedBody || !normalizedLabel || !normalizedUrl) {
+          return match;
+        }
+
+        return [
+          normalizedHeading,
+          '',
+          normalizedBody,
+          '',
+          `[${normalizedLabel}](${normalizedUrl})`,
+          '',
+          '',
+        ].join('\n');
+      }
+    );
+
+    normalized = normalized.replace(
+      /(\[[^\]\n]+]\([^)]+\))(?=\[[^\]\n]+]\([^)]+\))/g,
+      '$1\n'
+    );
+
+    normalized = normalized.replace(/^\[([^\n\]]+\[[^\]]+]\([^)]+\)[^\n]*)$/gm, '$1');
+
+    return normalized;
   }
 
   /**
@@ -578,10 +1185,167 @@ export class MarkdownService {
   _stripOpenAiPagerNavigation(markdown) {
     if (!markdown) return markdown;
 
-    return markdown.replace(
-      /\[\s*Previous[\s\S]*?]\([^)]+\)\s*\[\s*Next[\s\S]*?]\([^)]+\)\s*$/m,
+    const strippedByAst = this._stripOpenAiPagerNavigationWithAst(markdown);
+    if (strippedByAst !== markdown) {
+      return strippedByAst;
+    }
+
+    const strippedPair = markdown.replace(
+      /\[\s*Previous(?:\s|\n)[\s\S]*?]\([^)]+\)\s*\[\s*Next(?:\s|\n)[\s\S]*?]\([^)]+\)\s*$/,
       ''
     );
+
+    return strippedPair.replace(/(^|\n)\[\s*([\s\S]*?)\]\([^)]+\)\s*$/, (match, prefix, label) => {
+      const labelLines = String(label)
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      if (labelLines.length === 0) {
+        return match;
+      }
+
+      const firstLine = labelLines[0].toLowerCase();
+      if (firstLine === 'previous' || firstLine === 'next') {
+        return prefix;
+      }
+
+      return match;
+    });
+  }
+
+  /**
+   * 使用 Markdown AST 识别尾部 pager，避免误删正文中的方括号快捷键或普通链接。
+   *
+   * @param {string} markdown
+   * @returns {string}
+   * @private
+   */
+  _stripOpenAiPagerNavigationWithAst(markdown) {
+    try {
+      const tree = fromMarkdown(markdown);
+      const trailingPagerNodes = [];
+
+      for (let index = tree.children.length - 1; index >= 0; index -= 1) {
+        const node = tree.children[index];
+        const pagerKind = this._classifyOpenAiPagerNode(node);
+
+        if (!pagerKind) {
+          break;
+        }
+
+        trailingPagerNodes.unshift(node);
+      }
+
+      if (trailingPagerNodes.length === 0) {
+        return markdown;
+      }
+
+      const startOffset = trailingPagerNodes[0]?.position?.start?.offset;
+      if (typeof startOffset !== 'number') {
+        return markdown;
+      }
+
+      return markdown.slice(0, startOffset).replace(/\s*$/, '');
+    } catch {
+      return markdown;
+    }
+  }
+
+  /**
+   * 判断段落节点是否为 OpenAI 文档尾部 pager 链接。
+   *
+   * @param {import('mdast').Content} node
+   * @returns {'previous'|'next'|'previous-next'|null}
+   * @private
+   */
+  _classifyOpenAiPagerNode(node) {
+    if (!node || node.type !== 'paragraph' || !Array.isArray(node.children)) {
+      return null;
+    }
+
+    const linkChildren = [];
+
+    for (const child of node.children) {
+      if (child.type === 'text' && !(child.value || '').trim()) {
+        continue;
+      }
+
+      if (child.type !== 'link') {
+        return null;
+      }
+
+      linkChildren.push(child);
+    }
+
+    if (linkChildren.length === 0 || linkChildren.length > 2) {
+      return null;
+    }
+
+    const kinds = linkChildren.map((child) =>
+      this._classifyOpenAiPagerLabel(this._extractMdastText(child))
+    );
+
+    if (kinds.some((kind) => !kind)) {
+      return null;
+    }
+
+    if (kinds.length === 1) {
+      return kinds[0];
+    }
+
+    if (kinds.includes('previous') && kinds.includes('next')) {
+      return 'previous-next';
+    }
+
+    return null;
+  }
+
+  /**
+   * 将 mdast 节点中的纯文本拼接出来。
+   *
+   * @param {Object} node
+   * @returns {string}
+   * @private
+   */
+  _extractMdastText(node) {
+    if (!node) {
+      return '';
+    }
+
+    if (typeof node.value === 'string') {
+      return node.value;
+    }
+
+    if (!Array.isArray(node.children)) {
+      return '';
+    }
+
+    return node.children.map((child) => this._extractMdastText(child)).join('');
+  }
+
+  /**
+   * 识别 pager 链接标签首词。
+   *
+   * @param {string} label
+   * @returns {'previous'|'next'|null}
+   * @private
+   */
+  _classifyOpenAiPagerLabel(label) {
+    const normalized = String(label || '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+
+    if (normalized === 'previous' || normalized.startsWith('previous ')) {
+      return 'previous';
+    }
+
+    if (normalized === 'next' || normalized.startsWith('next ')) {
+      return 'next';
+    }
+
+    return null;
   }
 
   /**
@@ -598,6 +1362,49 @@ export class MarkdownService {
       /^AppRecommendedIDE extensionCodex in your IDECLICodex in your terminalCloudCodex in your browser$/m,
       ['- App (Recommended)', '- IDE extension', '- CLI', '- Cloud'].join('\n')
     );
+  }
+
+  /**
+   * 清理 Codex CLI 首页中由步骤卡片转换出来的重复数字与冗余标签。
+   *
+   * @param {string} markdown
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _normalizeOpenAiCliSetupCards(markdown, pageUrl = '') {
+    if (!markdown || !/\/codex\/cli\/?$/.test(pageUrl)) {
+      return markdown;
+    }
+
+    return markdown
+      .replace(/^(\d+)\.\s+\1\s*$/gm, '$1.')
+      .replace(/^\s*[A-Za-z][A-Za-z\s]+ command\s*$/gm, '');
+  }
+
+  /**
+   * 精简 Codex use-cases 首页里的筛选按钮与装饰性大图，避免目录页在 PDF 中被图片撑成多页。
+   *
+   * @param {string} markdown
+   * @param {string} pageUrl
+   * @returns {string}
+   * @private
+   */
+  _simplifyOpenAiUseCasesIndex(markdown, pageUrl = '') {
+    if (!markdown || !/\/codex\/use-cases\/?$/.test(pageUrl)) {
+      return markdown;
+    }
+
+    return markdown
+      .replace(
+        /^\[(?:[^\]]+)]\([^)]*\?search=[^)]+\)(?:\s+\[(?:[^\]]+)]\([^)]*\?search=[^)]+\))*\s*$/gm,
+        ''
+      )
+      .replace(
+        /^(?:#{1,6}\s+)?No use cases match these filters\s*\n+Try clearing a few filters or searching for a broader term\.\s*$/m,
+        ''
+      )
+      .replace(/^\s*(?:!\[[^\]]*]\([^)]+\)\s*)+\s*$/gm, '');
   }
 
   /**

--- a/src/services/markdownService.js
+++ b/src/services/markdownService.js
@@ -696,13 +696,77 @@ export class MarkdownService {
           )
           .forEach((node) => node.remove());
 
-        clone.querySelectorAll('nav').forEach((nav) => {
-          const pagerLabels = Array.from(nav.querySelectorAll('a'))
-            .map((link) => normalizeWhitespace(link.textContent || '').toLowerCase())
+        const normalizePagerLabel = (text = '') => normalizeWhitespace(text).toLowerCase();
+
+        const getPagerLinkInfo = (link) => {
+          if (!link) return null;
+
+          const label = normalizePagerLabel(link.textContent || '');
+          if (!label) return null;
+
+          const segments = Array.from(link.querySelectorAll('div, span, p, strong, small'))
+            .map((node) => normalizePagerLabel(getVisibleText(node)))
             .filter(Boolean);
 
-          const isPagerNav = pagerLabels.some((label) => label.startsWith('previous')) ||
-            pagerLabels.some((label) => label.startsWith('next'));
+          const exactSegmentKind = segments.find((segment) => segment === 'previous' || segment === 'next');
+          if (exactSegmentKind) {
+            return {
+              kind: exactSegmentKind,
+              exact: true,
+              hasTitle: segments.some((segment) => segment !== exactSegmentKind) || label !== exactSegmentKind,
+            };
+          }
+
+          if (label === 'previous' || label === 'next') {
+            return {
+              kind: label,
+              exact: true,
+              hasTitle: false,
+            };
+          }
+
+          const titledMatch = label.match(/^(previous|next)\s+\S/);
+          if (titledMatch) {
+            return {
+              kind: titledMatch[1],
+              exact: false,
+              hasTitle: true,
+            };
+          }
+
+          return null;
+        };
+
+        const shouldStripPagerLinks = (linkInfos, { requireExact = false } = {}) => {
+          if (!Array.isArray(linkInfos) || linkInfos.length === 0 || linkInfos.length > 2) {
+            return false;
+          }
+
+          if (linkInfos.some((info) => !info)) {
+            return false;
+          }
+
+          if (requireExact && linkInfos.some((info) => !info.exact)) {
+            return false;
+          }
+
+          const hasPrevious = linkInfos.some((info) => info.kind === 'previous');
+          const hasNext = linkInfos.some((info) => info.kind === 'next');
+
+          if (hasPrevious && hasNext) {
+            return true;
+          }
+
+          if (linkInfos.length === 1) {
+            return linkInfos[0].exact && !linkInfos[0].hasTitle;
+          }
+
+          return false;
+        };
+
+        clone.querySelectorAll('nav').forEach((nav) => {
+          const linkInfos = Array.from(nav.querySelectorAll('a')).map(getPagerLinkInfo);
+          const isPagerNav = shouldStripPagerLinks(linkInfos, { requireExact: true });
 
           if (isPagerNav) {
             nav.remove();
@@ -1225,19 +1289,25 @@ export class MarkdownService {
     try {
       const tree = fromMarkdown(markdown);
       const trailingPagerNodes = [];
+      const trailingPagerLinkInfos = [];
 
       for (let index = tree.children.length - 1; index >= 0; index -= 1) {
         const node = tree.children[index];
-        const pagerKind = this._classifyOpenAiPagerNode(node);
+        const pagerInfo = this._getOpenAiPagerNodeInfo(node);
 
-        if (!pagerKind) {
+        if (!pagerInfo) {
           break;
         }
 
         trailingPagerNodes.unshift(node);
+        trailingPagerLinkInfos.unshift(...pagerInfo.linkInfos);
       }
 
       if (trailingPagerNodes.length === 0) {
+        return markdown;
+      }
+
+      if (!this._shouldStripOpenAiPagerLinkGroup(trailingPagerLinkInfos)) {
         return markdown;
       }
 
@@ -1253,13 +1323,13 @@ export class MarkdownService {
   }
 
   /**
-   * 判断段落节点是否为 OpenAI 文档尾部 pager 链接。
+   * 提取段落节点中的 pager 链接信息。
    *
    * @param {import('mdast').Content} node
-   * @returns {'previous'|'next'|'previous-next'|null}
+   * @returns {{linkInfos: Array<{kind: 'previous'|'next', exact: boolean, hasTitle: boolean}>}|null}
    * @private
    */
-  _classifyOpenAiPagerNode(node) {
+  _getOpenAiPagerNodeInfo(node) {
     if (!node || node.type !== 'paragraph' || !Array.isArray(node.children)) {
       return null;
     }
@@ -1282,23 +1352,15 @@ export class MarkdownService {
       return null;
     }
 
-    const kinds = linkChildren.map((child) =>
-      this._classifyOpenAiPagerLabel(this._extractMdastText(child))
+    const linkInfos = linkChildren.map((child) =>
+      this._getOpenAiPagerLinkInfo(this._extractMdastText(child))
     );
 
-    if (kinds.some((kind) => !kind)) {
+    if (linkInfos.some((info) => !info)) {
       return null;
     }
 
-    if (kinds.length === 1) {
-      return kinds[0];
-    }
-
-    if (kinds.includes('previous') && kinds.includes('next')) {
-      return 'previous-next';
-    }
-
-    return null;
+    return { linkInfos };
   }
 
   /**
@@ -1325,27 +1387,100 @@ export class MarkdownService {
   }
 
   /**
-   * 识别 pager 链接标签首词。
+   * 规范化 pager 标签，便于跨 DOM / Markdown AST 共享判断逻辑。
    *
    * @param {string} label
-   * @returns {'previous'|'next'|null}
+   * @returns {string}
    * @private
    */
-  _classifyOpenAiPagerLabel(label) {
-    const normalized = String(label || '')
+  _normalizeOpenAiPagerLabel(label) {
+    return String(label || '')
       .replace(/\s+/g, ' ')
       .trim()
       .toLowerCase();
+  }
 
-    if (normalized === 'previous' || normalized.startsWith('previous ')) {
-      return 'previous';
+  /**
+   * 提取单个 pager 链接的方向与“是否显式 pager 控件”信息。
+   *
+   * @param {string} label
+   * @param {string[]} [segments]
+   * @returns {{kind: 'previous'|'next', exact: boolean, hasTitle: boolean}|null}
+   * @private
+   */
+  _getOpenAiPagerLinkInfo(label, segments = []) {
+    const normalized = this._normalizeOpenAiPagerLabel(label);
+    const normalizedSegments = segments
+      .map((segment) => this._normalizeOpenAiPagerLabel(segment))
+      .filter(Boolean);
+
+    const exactSegmentKind = normalizedSegments.find(
+      (segment) => segment === 'previous' || segment === 'next'
+    );
+
+    if (exactSegmentKind) {
+      return {
+        kind: exactSegmentKind,
+        exact: true,
+        hasTitle: normalizedSegments.some((segment) => segment !== exactSegmentKind) || normalized !== exactSegmentKind,
+      };
     }
 
-    if (normalized === 'next' || normalized.startsWith('next ')) {
-      return 'next';
+    if (normalized === 'previous' || normalized === 'next') {
+      return {
+        kind: normalized,
+        exact: true,
+        hasTitle: false,
+      };
+    }
+
+    const titledMatch = normalized.match(/^(previous|next)\s+\S/);
+    if (titledMatch) {
+      return {
+        kind: titledMatch[1],
+        exact: false,
+        hasTitle: true,
+      };
     }
 
     return null;
+  }
+
+  /**
+   * 判断一组 pager 链接是否足够明确，可以安全地当作页尾 pager 删除。
+   *
+   * @param {Array<{kind: 'previous'|'next', exact: boolean, hasTitle: boolean}>} linkInfos
+   * @param {{requireExact?: boolean}} [options]
+   * @returns {boolean}
+   * @private
+   */
+  _shouldStripOpenAiPagerLinkGroup(linkInfos, options = {}) {
+    const { requireExact = false } = options;
+
+    if (!Array.isArray(linkInfos) || linkInfos.length === 0 || linkInfos.length > 2) {
+      return false;
+    }
+
+    if (linkInfos.some((info) => !info)) {
+      return false;
+    }
+
+    if (requireExact && linkInfos.some((info) => !info.exact)) {
+      return false;
+    }
+
+    const hasPrevious = linkInfos.some((info) => info.kind === 'previous');
+    const hasNext = linkInfos.some((info) => info.kind === 'next');
+
+    if (hasPrevious && hasNext) {
+      return true;
+    }
+
+    if (linkInfos.length === 1) {
+      return linkInfos[0].exact && !linkInfos[0].hasTitle;
+    }
+
+    return false;
   }
 
   /**

--- a/src/services/pandocPdfService.js
+++ b/src/services/pandocPdfService.js
@@ -17,6 +17,7 @@ export class PandocPdfService {
     this.logger = options.logger;
     this.config = options.config || {};
     this.pandocBinary = options.pandocBinary || 'pandoc';
+    this.latexBinary = options.latexBinary || 'xelatex';
     this.metadataService = options.metadataService || null;
   }
 
@@ -120,12 +121,78 @@ export class PandocPdfService {
    * @private
    */
   async _runPandoc(inputPath, outputPath, options = {}) {
-    const args = this._buildPandocArgs(inputPath, outputPath, options);
+    const tempDir = path.dirname(inputPath) || process.cwd();
+    const headerIncludePath = this._createPandocHeaderFile(tempDir);
+    const latexWorkDir = fs.mkdtempSync(path.join(tempDir, 'pandoc-latex-'));
+    const latexInputPath = path.join(latexWorkDir, 'input.tex');
+    const latexOutputPath = path.join(latexWorkDir, 'input.pdf');
+    const args = this._buildPandocLatexArgs(inputPath, latexInputPath, {
+      ...options,
+      headerIncludePath,
+    });
+
+    return (async () => {
+      await this._runExternalCommand(this.pandocBinary, args, {
+        failureLabel: 'Pandoc 转换失败',
+        timeoutMs: 120000,
+      });
+
+      await this._runXeLatex(latexInputPath, latexWorkDir);
+      await this._runXeLatex(latexInputPath, latexWorkDir);
+
+      if (!fs.existsSync(latexOutputPath)) {
+        throw new Error('PDF 文件未生成');
+      }
+
+      fs.copyFileSync(latexOutputPath, outputPath);
+    })().finally(() => {
+      try {
+        fs.unlinkSync(headerIncludePath);
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      try {
+        fs.rmSync(latexWorkDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+  }
+
+  /**
+   * 运行一个外部命令并在失败时附带 stderr，便于定位 Pandoc / XeLaTeX 问题。
+   *
+   * @param {string} command
+   * @param {string[]} args
+   * @param {{ failureLabel: string, timeoutMs?: number }} options
+   * @returns {Promise<{stdout: string, stderr: string}>}
+   * @private
+   */
+  async _runExternalCommand(command, args, options = {}) {
+    const { failureLabel = '外部命令执行失败', timeoutMs = 300000 } = options;
 
     return new Promise((resolve, reject) => {
-      const child = spawn(this.pandocBinary, args);
+      const child = spawn(command, args);
       let stdout = '';
       let stderr = '';
+      let settled = false;
+      const timeoutId = setTimeout(() => {
+        if (settled) return;
+
+        child.kill('SIGTERM');
+        settled = true;
+        reject(new Error(`${failureLabel}: timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      timeoutId.unref?.();
+
+      const finish = (handler) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        handler();
+      };
 
       child.stdout.on('data', (data) => {
         stdout += data.toString();
@@ -136,33 +203,53 @@ export class PandocPdfService {
       });
 
       child.on('close', (code) => {
-        if (code !== 0) {
-          const error = new Error(`Pandoc exited with code ${code}: ${stderr}`);
-          this.logger?.error?.('Pandoc 转换失败', {
-            code,
-            stderr: stderr.substring(0, 500),
-            stdout: stdout.substring(0, 500),
+        finish(() => {
+          if (code !== 0) {
+            this.logger?.error?.(failureLabel, {
+              code,
+              stderr: stderr.substring(0, 500),
+              stdout: stdout.substring(0, 500),
+            });
+            reject(new Error(`${failureLabel}: ${stderr || stdout || `exit code ${code}`}`));
+            return;
+          }
+
+          resolve({ stdout, stderr });
+        });
+      });
+
+      child.on('error', (error) => {
+        finish(() => {
+          this.logger?.error?.(`${failureLabel} spawn 错误`, {
+            error: error.message,
           });
           reject(error);
-          return;
-        }
-
-        // 检查输出文件是否存在
-        if (!fs.existsSync(outputPath)) {
-          reject(new Error('PDF 文件未生成'));
-          return;
-        }
-
-        resolve();
-      });
-
-      child.on('error', (err) => {
-        this.logger?.error?.('Pandoc spawn 错误', {
-          error: err.message,
         });
-        reject(err);
       });
     });
+  }
+
+  /**
+   * 显式运行 XeLaTeX，确保 TOC / 引用在多轮编译中稳定收敛。
+   *
+   * @param {string} inputPath
+   * @param {string} outputDir
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _runXeLatex(inputPath, outputDir) {
+    await this._runExternalCommand(
+      this.latexBinary,
+      [
+        '-halt-on-error',
+        '-interaction=nonstopmode',
+        `-output-directory=${outputDir}`,
+        inputPath,
+      ],
+      {
+        failureLabel: 'XeLaTeX 转换失败',
+      }
+    );
   }
 
   /**
@@ -1127,6 +1214,12 @@ export class PandocPdfService {
     fs.mkdirSync(mediaDir, { recursive: true });
 
     const digest = createHash('sha256').update(url).digest('hex').slice(0, 24);
+    const outputPath = path.join(mediaDir, `${digest}.png`);
+
+    if (fs.existsSync(outputPath)) {
+      return outputPath;
+    }
+
     const response = await fetch(url, {
       headers: {
         'user-agent': 'documentation-pdf-scraper/1.0',
@@ -1139,21 +1232,24 @@ export class PandocPdfService {
     }
 
     const contentType = response.headers.get('content-type') || '';
-    const sourceExtension = this._getImageExtensionFromUrl(url, contentType);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const detectedFormat = this._detectDownloadedImageFormat(buffer, contentType);
+    const sourceExtension = this._getImageExtensionFromUrl(url, contentType, detectedFormat);
     const sourcePath = path.join(mediaDir, `${digest}${sourceExtension}`);
-    const outputPath = path.join(mediaDir, `${digest}.png`);
+    const shouldConvert = this._shouldConvertDownloadedImage(url, contentType, detectedFormat);
 
-    if (fs.existsSync(outputPath)) {
+    if (fs.existsSync(sourcePath)) {
+      if (!shouldConvert) {
+        return sourcePath;
+      }
+
+      await this._convertImageToPng(sourcePath, outputPath);
       return outputPath;
     }
-    if (fs.existsSync(sourcePath) && !this._shouldConvertDownloadedImage(url, contentType)) {
-      return sourcePath;
-    }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
     await fs.promises.writeFile(sourcePath, buffer);
 
-    if (!this._shouldConvertDownloadedImage(url, contentType)) {
+    if (!shouldConvert) {
       return sourcePath;
     }
 
@@ -1180,8 +1276,26 @@ export class PandocPdfService {
    * @returns {boolean}
    * @private
    */
-  _shouldConvertDownloadedImage(url, contentType = '') {
+  _shouldConvertDownloadedImage(url, contentType = '', detectedFormat = '') {
+    const normalizedFormat = detectedFormat.toLowerCase();
     const normalizedType = contentType.toLowerCase();
+
+    if (normalizedFormat === 'png' || normalizedFormat === 'jpg' || normalizedFormat === 'jpeg') {
+      return false;
+    }
+
+    if (normalizedFormat === 'pdf') {
+      return false;
+    }
+
+    if (
+      normalizedFormat === 'webp'
+      || normalizedFormat === 'avif'
+      || normalizedFormat === 'gif'
+      || normalizedFormat === 'svg'
+    ) {
+      return true;
+    }
 
     if (normalizedType.includes('image/png') || normalizedType.includes('image/jpeg')) {
       return false;
@@ -1197,6 +1311,80 @@ export class PandocPdfService {
     if (normalizedType.includes('image/svg+xml')) return true;
 
     return this._isPdfUnsafeImageUrl(url);
+  }
+
+  /**
+   * 根据真实下载内容识别图片格式，避免仅靠 URL 或响应头做脆弱判断。
+   *
+   * @param {Buffer} buffer
+   * @param {string} contentType
+   * @returns {string}
+   * @private
+   */
+  _detectDownloadedImageFormat(buffer, contentType = '') {
+    if (Buffer.isBuffer(buffer) && buffer.length > 0) {
+      if (
+        buffer.length >= 8
+        && buffer[0] === 0x89
+        && buffer[1] === 0x50
+        && buffer[2] === 0x4e
+        && buffer[3] === 0x47
+        && buffer[4] === 0x0d
+        && buffer[5] === 0x0a
+        && buffer[6] === 0x1a
+        && buffer[7] === 0x0a
+      ) {
+        return 'png';
+      }
+
+      if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+        return 'jpg';
+      }
+
+      const leadingAscii = buffer.subarray(0, Math.min(buffer.length, 512)).toString('utf8');
+      const trimmedLeadingAscii = leadingAscii.replace(/^\uFEFF/, '').trimStart().toLowerCase();
+
+      if (trimmedLeadingAscii.includes('<svg')) {
+        return 'svg';
+      }
+
+      if (buffer.length >= 6) {
+        const gifSignature = buffer.subarray(0, 6).toString('ascii');
+        if (gifSignature === 'GIF87a' || gifSignature === 'GIF89a') {
+          return 'gif';
+        }
+      }
+
+      if (
+        buffer.length >= 12
+        && buffer.subarray(0, 4).toString('ascii') === 'RIFF'
+        && buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+      ) {
+        return 'webp';
+      }
+
+      if (buffer.length >= 5 && buffer.subarray(0, 5).toString('ascii') === '%PDF-') {
+        return 'pdf';
+      }
+
+      if (buffer.length >= 12 && buffer.subarray(4, 8).toString('ascii') === 'ftyp') {
+        const brand = buffer.subarray(8, 12).toString('ascii');
+        if (brand === 'avif' || brand === 'avis') {
+          return 'avif';
+        }
+      }
+    }
+
+    const normalizedType = contentType.toLowerCase();
+    if (normalizedType.includes('image/png')) return 'png';
+    if (normalizedType.includes('image/jpeg')) return 'jpg';
+    if (normalizedType.includes('image/webp')) return 'webp';
+    if (normalizedType.includes('image/avif')) return 'avif';
+    if (normalizedType.includes('image/gif')) return 'gif';
+    if (normalizedType.includes('image/svg+xml')) return 'svg';
+    if (normalizedType.includes('application/pdf')) return 'pdf';
+
+    return '';
   }
 
   /**
@@ -1241,8 +1429,17 @@ export class PandocPdfService {
    * @returns {string}
    * @private
    */
-  _getImageExtensionFromUrl(url, contentType = '') {
+  _getImageExtensionFromUrl(url, contentType = '', detectedFormat = '') {
+    const normalizedFormat = detectedFormat.toLowerCase();
     const normalizedType = contentType.toLowerCase();
+    if (normalizedFormat === 'png') return '.png';
+    if (normalizedFormat === 'jpg' || normalizedFormat === 'jpeg') return '.jpg';
+    if (normalizedFormat === 'webp') return '.webp';
+    if (normalizedFormat === 'avif') return '.avif';
+    if (normalizedFormat === 'gif') return '.gif';
+    if (normalizedFormat === 'svg') return '.svg';
+    if (normalizedFormat === 'pdf') return '.pdf';
+
     if (normalizedType.includes('image/png')) return '.png';
     if (normalizedType.includes('image/jpeg')) return '.jpg';
     if (normalizedType.includes('image/webp')) return '.webp';
@@ -1262,6 +1459,41 @@ export class PandocPdfService {
     } catch {
       return '.img';
     }
+  }
+
+  /**
+   * 通过临时 header 文件注入 LaTeX 配置，避免 Pandoc 对 header-includes
+   * 变量做额外转义，导致 `\\usepackage` 之类的坏输出。
+   *
+   * @returns {string}
+   * @private
+   */
+  _getPandocHeaderContent() {
+    return String.raw`\usepackage{fvextra}
+\RecustomVerbatimEnvironment{verbatim}{Verbatim}{breaklines,breakanywhere,fontsize=\small}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,fontsize=\small,commandchars=\\\{\}}
+\usepackage{xurl}
+`;
+  }
+
+  /**
+   * 创建 Pandoc 头文件，供 --include-in-header 使用。
+   *
+   * @param {string} tempDir
+   * @returns {string}
+   * @private
+   */
+  _createPandocHeaderFile(tempDir) {
+    fs.mkdirSync(tempDir, { recursive: true });
+
+    const headerPath = path.join(
+      tempDir,
+      `pandoc-header-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.tex`
+    );
+
+    fs.writeFileSync(headerPath, this._getPandocHeaderContent(), 'utf8');
+
+    return headerPath;
   }
 
   /**
@@ -1411,9 +1643,11 @@ export class PandocPdfService {
       `CJKmainfont=${cjkMainFont}`, // 主字体（使用 CI 可用的开源字体，支持通过配置覆盖）
       '--variable',
       'geometry:margin=1in', // 页边距
-      '--variable',
-      'header-includes=\\usepackage{fvextra} \\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,fontsize=\\\\small,commandchars=\\\\\\{\\}} \\usepackage{xurl}', // 启用代码换行(支持任意位置)、缩小代码字号并增强 URL 换行。不再使用 ltablex 防止表格溢出
     ];
+
+    if (markdownPdfConfig.headerIncludePath) {
+      args.push('--include-in-header', markdownPdfConfig.headerIncludePath);
+    }
 
     // 添加其他选项
     const pdfOptions = markdownPdfConfig.pdfOptions || {};
@@ -1442,6 +1676,25 @@ export class PandocPdfService {
       const style = highlightStyle === 'github' ? 'pygments' : highlightStyle;
       args.push('--highlight-style', style);
     }
+
+    return args;
+  }
+
+  /**
+   * 构建 Pandoc -> LaTeX 的命令行参数。
+   *
+   * @param {string} inputPath
+   * @param {string} outputPath
+   * @param {Object} options
+   * @returns {string[]}
+   * @private
+   */
+  _buildPandocLatexArgs(inputPath, outputPath, options = {}) {
+    const args = this._buildPandocArgs(inputPath, outputPath, options).filter(
+      (arg) => arg !== '--pdf-engine=xelatex'
+    );
+
+    args.push('--standalone', '--to=latex');
 
     return args;
   }

--- a/tests/services/markdownService.test.js
+++ b/tests/services/markdownService.test.js
@@ -36,6 +36,29 @@ describe('MarkdownService', () => {
     expect(markdown).toContain('![Hero](https://developers.openai.com/images/hero.png)');
   });
 
+  test('convertHtmlToMarkdown 应该将 HTML table 转为可读的 Markdown 表格', () => {
+    const service = new MarkdownService({ logger });
+    const html = [
+      '<table>',
+      '<thead><tr><th></th><th>Action</th><th>macOS shortcut</th></tr></thead>',
+      '<tbody>',
+      '<tr><td><strong>Thread</strong></td><td></td><td></td></tr>',
+      '<tr><td></td><td>Previous thread</td><td><kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd></td></tr>',
+      '<tr><td></td><td>Next thread</td><td><kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd></td></tr>',
+      '</tbody>',
+      '</table>',
+    ].join('');
+
+    const markdown = service.convertHtmlToMarkdown(html, {
+      pageUrl: 'https://developers.openai.com/codex/app/commands',
+    });
+
+    expect(markdown).toContain('|   | Action | macOS shortcut |');
+    expect(markdown).toContain('| **Thread** |   |   |');
+    expect(markdown).toContain('|   | Previous thread | `Cmd` + `Shift` + `[` |');
+    expect(markdown).toContain('|   | Next thread | `Cmd` + `Shift` + `]` |');
+  });
+
   test('normalizeResourceUrls 应该处理 markdown 链接、图片和 srcset', () => {
     const service = new MarkdownService({ logger });
     const markdown = [
@@ -105,6 +128,20 @@ describe('MarkdownService', () => {
       line.trim().match(/^[_*]Figure 1: Caption here[_*]$/)
     );
     expect(duplicateItalic).toBe(false);
+  });
+
+  test('convertHtmlToMarkdown 应该将图片后直接粘连的正文拆成独立段落', () => {
+    const service = new MarkdownService({ logger });
+    const html =
+      '<p><img src="/images/guide.png" alt="">In this guide, we share practical examples.</p>';
+
+    const markdown = service.convertHtmlToMarkdown(html, {
+      pageUrl: 'https://developers.openai.com/codex/guides/build-ai-native-engineering-team',
+    });
+
+    expect(markdown).toContain(
+      '![](https://developers.openai.com/images/guide.png)\n\nIn this guide, we share practical examples.'
+    );
   });
 
   test('convertHtmlToMarkdown 应该剥离 <script>/<style>/<noscript> 内容', () => {
@@ -177,6 +214,260 @@ describe('MarkdownService', () => {
     expect(result).toContain('- IDE extension');
     expect(result).toContain('- CLI');
     expect(result).toContain('- Cloud');
+  });
+
+  test('sanitizeMarkdown 应该修复带图片的 OpenAI 卡片整块链接并补全相对链接', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '![](https://developers.openai.com/codex/use-cases/gh-pr-use-case.png)',
+      '',
+      '### Review pull requests faster',
+      '',
+      'Catch regressions and potential issues before human review.',
+      '',
+      'Integrations Workflow',
+      '',
+      '](/codex/use-cases/github-code-reviews)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/use-cases',
+    });
+
+    expect(result).toContain(
+      '### [Review pull requests faster](https://developers.openai.com/codex/use-cases/github-code-reviews)'
+    );
+    expect(result).toContain('Catch regressions and potential issues before human review.');
+    expect(result).toContain('Integrations Workflow');
+  });
+
+  test('sanitizeMarkdown 应该正确拆分粘连的 OpenAI 集合卡片', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '[',
+      '',
+      '![](https://developers.openai.com/codex/use-cases/background-codex-collection1.png) ![](https://developers.openai.com/codex/use-cases/production-systems-illustration.png)',
+      '',
+      '## Production systems',
+      '',
+      'Use Codex to navigate real codebases, make controlled changes, codify repeatable work, and keep production quality high.](/codex/use-cases/collections/production-systems) [![](https://developers.openai.com/codex/use-cases/background-codex-collection2.png) ![](https://developers.openai.com/codex/use-cases/analysis-collaboration-illustration.png)',
+      '',
+      '## Productivity and collaboration',
+      '',
+      'Work with Codex to analyze data and complex source material, combine multiple apps and services, and turn insights into action.](/codex/use-cases/collections/productivity-and-collaboration)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/use-cases',
+    });
+
+    expect(result).toContain(
+      '## [Production systems](https://developers.openai.com/codex/use-cases/collections/production-systems)'
+    );
+    expect(result).toContain(
+      '## [Productivity and collaboration](https://developers.openai.com/codex/use-cases/collections/productivity-and-collaboration)'
+    );
+    expect(result).not.toContain('](/codex/use-cases/collections/production-systems) [![]');
+  });
+
+  test('sanitizeMarkdown 应该精简 Codex Use Cases 首页里的筛选按钮和装饰性大图', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '# Codex Use Cases',
+      '',
+      '[Workflow](https://developers.openai.com/codex/use-cases?search=Workflow) [Integrations](https://developers.openai.com/codex/use-cases?search=Integrations) [Knowledge Work](https://developers.openai.com/codex/use-cases?search=Knowledge+Work)',
+      '',
+      '## Collections',
+      '',
+      '![](https://developers.openai.com/codex/use-cases/background-codex-collection1.png) ![](https://developers.openai.com/codex/use-cases/production-systems-illustration.png)',
+      '',
+      '## [Production systems](https://developers.openai.com/codex/use-cases/collections/production-systems)',
+      '',
+      'Use Codex to navigate real codebases, make controlled changes, codify repeatable work, and keep production quality high.',
+      '',
+      '## All use cases',
+      '',
+      '![](https://developers.openai.com/images/codex/codex-wallpaper-1.webp)',
+      '',
+      '### [Add iOS app intents](https://developers.openai.com/codex/use-cases/ios-app-intents)',
+      '',
+      'Use Codex to make your app’s actions and content available to Shortcuts, Siri, Spotlight...',
+      '',
+      'iOS Code',
+      '',
+      '## No use cases match these filters',
+      '',
+      'Try clearing a few filters or searching for a broader term.',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/use-cases',
+    });
+
+    expect(result).toContain('# Codex Use Cases');
+    expect(result).toContain(
+      '## [Production systems](https://developers.openai.com/codex/use-cases/collections/production-systems)'
+    );
+    expect(result).toContain(
+      '### [Add iOS app intents](https://developers.openai.com/codex/use-cases/ios-app-intents)'
+    );
+    expect(result).not.toContain('?search=Workflow');
+    expect(result).not.toContain('background-codex-collection1.png');
+    expect(result).not.toContain('codex-wallpaper-1.webp');
+    expect(result).not.toContain('No use cases match these filters');
+  });
+
+  test('sanitizeMarkdown 不应在非 OpenAI 页面误删正文里的 Copied', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = ['# Heading', '', 'Copied', '', 'Regular content'].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://example.com/docs/page',
+    });
+
+    expect(result).toContain('Copied');
+    expect(result).toContain('Regular content');
+  });
+
+  test('sanitizeMarkdown 应该清理 Codex CLI 首页步骤卡片里的重复数字和 command 标签', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '1.  1',
+      '',
+      '    ### Install',
+      '',
+      '    Install the Codex CLI with npm.',
+      '',
+      '    npm install command',
+      '',
+      '    npm i -g @openai/codex',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/cli',
+    });
+
+    expect(result).toContain('1.');
+    expect(result).not.toContain('1.  1');
+    expect(result).not.toContain('npm install command');
+  });
+
+  test('sanitizeMarkdown 应该只移除尾部 pager 而不误删快捷键方括号', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      'Action',
+      '',
+      'Previous thread',
+      '',
+      'Cmd + Shift + \\[',
+      '',
+      '[Previous Settings](/codex/app/settings)',
+      '',
+      '[Next Windows](/codex/app/windows)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/app/commands',
+    });
+
+    expect(result).toContain('Previous thread');
+    expect(result).toContain('Cmd + Shift + \\[');
+    expect(result).not.toContain('Previous Settings');
+    expect(result).not.toContain('Next Windows');
+  });
+
+  test('normalizeOpenAiModelsPage 应该把 Codex Models 卡片重建为紧凑可读的列表', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '# Codex Models',
+      '',
+      '## Recommended models',
+      '',
+      '![gpt-5.4](https://developers.openai.com/images/api/models/gpt-5.4.jpg)',
+      '',
+      'gpt-5.4',
+      '',
+      'Flagship frontier model for professional work.',
+      '',
+      'codex -m gpt-5.4',
+      '',
+      'Capability',
+      '',
+      'Speed',
+      '',
+      'Codex CLI & SDK',
+      '',
+      'Codex Cloud',
+      '',
+      'For most tasks in Codex, start with `gpt-5.4`.',
+      '',
+      '## Alternative models',
+      '',
+      'gpt-5.2',
+      '',
+      'Previous general-purpose model.',
+      '',
+      'codex -m gpt-5.2',
+      '',
+      'Show details',
+      '',
+      '## Other models',
+      '',
+      'When you sign in with ChatGPT, Codex works best with the models listed above.',
+    ].join('\n');
+
+    const result = service._normalizeOpenAiModelsPage(
+      markdown,
+      [
+        {
+          heading: 'Recommended models',
+          cards: [
+            {
+              name: 'gpt-5.4',
+              description: 'Flagship frontier model for professional work.',
+              command: 'codex -m gpt-5.4',
+              features: [
+                { title: 'Capability', iconCount: 5, value: '' },
+                { title: 'Speed', iconCount: 3, value: '' },
+                { title: 'Codex CLI & SDK', value: true, iconCount: 0 },
+                { title: 'Codex Cloud', value: false, iconCount: 0 },
+              ],
+            },
+          ],
+          notes: ['For most tasks in Codex, start with gpt-5.4.'],
+        },
+        {
+          heading: 'Alternative models',
+          cards: [
+            {
+              name: 'gpt-5.2',
+              description: 'Previous general-purpose model.',
+              command: 'codex -m gpt-5.2',
+              features: [
+                { title: 'Capability', iconCount: 4, value: '' },
+                { title: 'Speed', iconCount: 3, value: '' },
+                { title: 'Codex CLI & SDK', value: true, iconCount: 0 },
+              ],
+            },
+          ],
+          notes: [],
+        },
+      ],
+      'https://developers.openai.com/codex/models'
+    );
+
+    expect(result).toContain('### gpt-5.4');
+    expect(result).toContain('```bash\ncodex -m gpt-5.4\n```');
+    expect(result).toContain('- Capability: 5/5');
+    expect(result).toContain('- Speed: 3/3');
+    expect(result).toContain('- Codex CLI & SDK: Yes');
+    expect(result).toContain('- Codex Cloud: No');
+    expect(result).toContain('For most tasks in Codex, start with `gpt-5.4`.');
+    expect(result).toContain('### gpt-5.2');
+    expect(result).not.toContain('![gpt-5.4]');
+    expect(result).not.toContain('Show details');
   });
 
   test('sanitizeMarkdown 应该收敛 OpenAI 文档相邻的 light/dark 主题截图', () => {

--- a/tests/services/markdownService.test.js
+++ b/tests/services/markdownService.test.js
@@ -378,6 +378,23 @@ describe('MarkdownService', () => {
     expect(result).not.toContain('Next Windows');
   });
 
+  test('sanitizeMarkdown 不应把尾部正常链接误判为 pager', () => {
+    const service = new MarkdownService({ logger });
+    const markdown = [
+      '# Agents.md',
+      '',
+      'Learn how to customize repository instructions.',
+      '',
+      '[Next steps](https://developers.openai.com/codex/guides/next-steps)',
+    ].join('\n');
+
+    const result = service.sanitizeMarkdown(markdown, {
+      pageUrl: 'https://developers.openai.com/codex/guides/agents-md',
+    });
+
+    expect(result).toContain('[Next steps](https://developers.openai.com/codex/guides/next-steps)');
+  });
+
   test('normalizeOpenAiModelsPage 应该把 Codex Models 卡片重建为紧凑可读的列表', () => {
     const service = new MarkdownService({ logger });
     const markdown = [
@@ -563,5 +580,36 @@ describe('MarkdownService', () => {
     expect(page.evaluate).toHaveBeenCalledTimes(1);
     expect(markdown).toContain('Title');
     expect(markdown).toContain('![Body](https://developers.openai.com/images/body.png)');
+  });
+
+  test('_getOpenAiPagerLinkInfo 和 _shouldStripOpenAiPagerLinkGroup 应该区分真正 pager 与普通 Next 链接', () => {
+    const service = new MarkdownService({ logger });
+    const previousInfo = service._getOpenAiPagerLinkInfo('Previous Settings', ['Previous', 'Settings']);
+    const nextInfo = service._getOpenAiPagerLinkInfo('Next Automations', ['Next', 'Automations']);
+    const nextStepsInfo = service._getOpenAiPagerLinkInfo('Next steps', ['Next steps']);
+
+    expect(previousInfo).toEqual({
+      kind: 'previous',
+      exact: true,
+      hasTitle: true,
+    });
+    expect(nextInfo).toEqual({
+      kind: 'next',
+      exact: true,
+      hasTitle: true,
+    });
+    expect(nextStepsInfo).toEqual({
+      kind: 'next',
+      exact: false,
+      hasTitle: true,
+    });
+
+    expect(
+      service._shouldStripOpenAiPagerLinkGroup([previousInfo, nextInfo], { requireExact: true })
+    ).toBe(true);
+    expect(
+      service._shouldStripOpenAiPagerLinkGroup([nextStepsInfo], { requireExact: true })
+    ).toBe(false);
+    expect(service._shouldStripOpenAiPagerLinkGroup([nextStepsInfo])).toBe(false);
   });
 });

--- a/tests/services/pandocPdfService.test.js
+++ b/tests/services/pandocPdfService.test.js
@@ -126,6 +126,37 @@ describe('PandocPdfService', () => {
       expect(args).not.toContain('CJKmainfont=Arial Unicode MS');
     });
 
+    it('should include a header file instead of raw header-includes latex', () => {
+      const args = service._buildPandocArgs('input.md', 'output.pdf', {
+        headerIncludePath: '/tmp/pandoc-header.tex',
+      });
+
+      expect(args).toContain('--include-in-header');
+      expect(args).toContain('/tmp/pandoc-header.tex');
+      expect(args.some((arg) => arg.includes('header-includes='))).toBe(false);
+    });
+
+    it('should build latex args without invoking pandoc pdf-engine orchestration', () => {
+      const args = service._buildPandocLatexArgs('input.md', 'output.tex', {
+        headerIncludePath: '/tmp/pandoc-header.tex',
+      });
+
+      expect(args).toContain('--standalone');
+      expect(args).toContain('--to=latex');
+      expect(args).not.toContain('--pdf-engine=xelatex');
+    });
+
+    it('should configure both Highlighting and plain verbatim blocks to wrap long lines', () => {
+      const header = service._getPandocHeaderContent();
+
+      expect(header).toContain(
+        '\\RecustomVerbatimEnvironment{verbatim}{Verbatim}{breaklines,breakanywhere,fontsize=\\small}'
+      );
+      expect(header).toContain(
+        '\\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,fontsize=\\small,commandchars=\\\\\\{\\}}'
+      );
+    });
+
     it('should allow overriding the CJK main font from config', () => {
       const customService = new PandocPdfService({
         logger: mockLogger,
@@ -610,25 +641,103 @@ describe('PandocPdfService', () => {
     });
   });
 
+  describe('_detectDownloadedImageFormat', () => {
+    it('should detect webp from bytes even when headers are missing', () => {
+      const webpBuffer = Buffer.concat([
+        Buffer.from('RIFF', 'ascii'),
+        Buffer.from([0x00, 0x00, 0x00, 0x00]),
+        Buffer.from('WEBP', 'ascii'),
+      ]);
+
+      expect(service._detectDownloadedImageFormat(webpBuffer, '')).toBe('webp');
+    });
+
+    it('should still convert when the detected format is unsafe even if the url looks safe', () => {
+      expect(
+        service._shouldConvertDownloadedImage(
+          'https://cdn.example.com/chart?fm=png',
+          '',
+          'webp'
+        )
+      ).toBe(true);
+    });
+  });
+
   describe('_runPandoc', () => {
-    it('should reject if output file not created', async () => {
+    it('should create and cleanup a pandoc header include file for each run', async () => {
       const inputPath = path.join(tempDir, 'input.md');
       const outputPath = path.join(tempDir, 'output.pdf');
+      let headerPath = '';
+      let invocation = 0;
 
       fs.writeFileSync(inputPath, '# Test', 'utf8');
 
-      // Mock spawn to simulate success but no file
-      const spawnSpy = vi.mocked(spawn).mockImplementation(() => {
-        const mockChild = {
+      const spawnSpy = vi.mocked(spawn).mockImplementation((_command, args) => {
+        invocation += 1;
+        const currentInvocation = invocation;
+        return {
           stdout: { on: vi.fn() },
           stderr: { on: vi.fn() },
           on: vi.fn((event, callback) => {
             if (event === 'close') {
-              setTimeout(() => callback(0), 10); // Exit code 0
+              setTimeout(() => {
+                if (currentInvocation === 1) {
+                  const includeIndex = args.indexOf('--include-in-header');
+                  headerPath = includeIndex >= 0 ? args[includeIndex + 1] : '';
+                  expect(headerPath).toBeTruthy();
+                  expect(fs.existsSync(headerPath)).toBe(true);
+
+                  const outputIndex = args.indexOf('-o');
+                  fs.writeFileSync(args[outputIndex + 1], '\\documentclass{article}', 'utf8');
+                } else {
+                  const outputDirArg = args.find((arg) => arg.startsWith('-output-directory='));
+                  const outputDir = outputDirArg?.slice('-output-directory='.length) || tempDir;
+                  fs.writeFileSync(path.join(outputDir, 'input.pdf'), '%PDF-1.4', 'utf8');
+                }
+
+                callback(0);
+              }, 10);
             }
           }),
         };
-        return mockChild;
+      });
+
+      await service._runPandoc(inputPath, outputPath, {});
+
+      expect(fs.existsSync(outputPath)).toBe(true);
+      expect(fs.existsSync(headerPath)).toBe(false);
+      expect(spawnSpy).toHaveBeenCalledTimes(3);
+
+      spawnSpy.mockReset();
+    });
+
+    it('should reject if output file not created', async () => {
+      const inputPath = path.join(tempDir, 'input.md');
+      const outputPath = path.join(tempDir, 'output.pdf');
+      let invocation = 0;
+
+      fs.writeFileSync(inputPath, '# Test', 'utf8');
+
+      // Mock spawn to simulate success but no file
+      const spawnSpy = vi.mocked(spawn).mockImplementation((_command, args) => {
+        invocation += 1;
+        const currentInvocation = invocation;
+
+        return {
+          stdout: { on: vi.fn() },
+          stderr: { on: vi.fn() },
+          on: vi.fn((event, callback) => {
+            if (event === 'close') {
+              setTimeout(() => {
+                if (currentInvocation === 1) {
+                  const outputIndex = args.indexOf('-o');
+                  fs.writeFileSync(args[outputIndex + 1], '\\documentclass{article}', 'utf8');
+                }
+                callback(0);
+              }, 10); // Exit code 0
+            }
+          }),
+        };
       });
 
       await expect(service._runPandoc(inputPath, outputPath, {})).rejects.toThrow('PDF 文件未生成');


### PR DESCRIPTION
## Summary
- make OpenAI-specific markdown extraction more structural and less regex-fragile
- harden the Pandoc/XeLaTeX pipeline for long code blocks, header injection, and remote image handling
- document the lessons learned in `AGENTS.md` and add regression coverage

## What changed
- convert OpenAI tables and `kbd` elements into structured markdown before flattening
- normalize OpenAI card/tab/pager patterns in a site-scoped way so `use-cases`, `quickstart`, `models`, and `commands` render cleanly
- split malformed image-plus-text lines into separate blocks before Pandoc
- switch Pandoc PDF generation to an explicit `pandoc -> latex -> xelatex` flow using `--include-in-header`
- detect downloaded image formats from bytes instead of guessing from URLs/query params
- wrap both Pandoc `Highlighting` and plain `verbatim` code blocks so long lines do not run off the page

## Verification
- `DOC_TARGET=openai-docs make run`
  - scrape: `75/75` success
  - merged PDF: `pdfs/finalPdf/developers_openai_com_batch_20260422_258644.pdf`
- `make test`
  - `34` files, `698` tests passed
- `make lint`
- manual PDF spot checks
  - `page 26`: Codex Use Cases layout
  - `pages 57-58`: Models cards rendered as compact readable sections
  - `pages 93-94`: app Commands tables/deeplinks page
  - `pages 258-261`: Hooks code blocks and tables
  - `pages 285-287`: Subagents TOML/code examples
  - `pages 358-361`: Agents SDK code-heavy pages
  - `pages 377-379`: AI-native engineering team guide
